### PR TITLE
RAC-83 feat : 멘토링 일부 및 대학생 마이페이지 작업

### DIFF
--- a/src/main/java/com/postgraduate/domain/mentoring/application/dto/AppliedMentoringDetailResponse.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/dto/AppliedMentoringDetailResponse.java
@@ -1,0 +1,21 @@
+package com.postgraduate.domain.mentoring.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AppliedMentoringDetailResponse {
+        Long seniorId;
+        String nickName;
+        String field;
+        String lab;
+        String professor;
+        String topic;
+        String question;
+        List<String> dates;
+}

--- a/src/main/java/com/postgraduate/domain/mentoring/application/dto/AppliedMentoringInfo.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/dto/AppliedMentoringInfo.java
@@ -9,13 +9,14 @@ import java.util.List;
 @Getter
 @Builder
 @AllArgsConstructor
-public class MentoringInfo {
+public class AppliedMentoringInfo {
     Long mentoringId;
     Long seniorId;
     String nickName;
     String postgradu;
     String field;
     String lab;
+    String professor;
     List<String> dates;
     int term;
     String chatLink;

--- a/src/main/java/com/postgraduate/domain/mentoring/application/dto/AppliedMentoringInfo.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/dto/AppliedMentoringInfo.java
@@ -17,7 +17,7 @@ public class AppliedMentoringInfo {
     String field;
     String lab;
     String professor;
-    List<String> dates;
+    String[] dates;
     int term;
     String chatLink;
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/application/dto/AppliedMentoringResponse.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/dto/AppliedMentoringResponse.java
@@ -10,5 +10,5 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 public class AppliedMentoringResponse {
-    List<MentoringInfo> mentoringInfos;
+    List<AppliedMentoringInfo> appliedMentoringInfos;
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/application/dto/AppliedMentoringResponse.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/dto/AppliedMentoringResponse.java
@@ -1,0 +1,14 @@
+package com.postgraduate.domain.mentoring.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AppliedMentoringResponse {
+    List<MentoringInfo> mentoringInfos;
+}

--- a/src/main/java/com/postgraduate/domain/mentoring/application/dto/MentoringInfo.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/dto/MentoringInfo.java
@@ -1,0 +1,22 @@
+package com.postgraduate.domain.mentoring.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MentoringInfo {
+    Long mentoringId;
+    Long seniorId;
+    String nickName;
+    String postgradu;
+    String field;
+    String lab;
+    List<String> dates;
+    int term;
+    String chatLink;
+}

--- a/src/main/java/com/postgraduate/domain/mentoring/application/mapper/MentoringMapper.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/mapper/MentoringMapper.java
@@ -11,8 +11,7 @@ import java.util.stream.Stream;
 public class MentoringMapper {
     public static AppliedMentoringInfo mapToExpectedAppliedInfo(Mentoring mentoring) {
         Senior senior = mentoring.getSenior();
-        List<String> dates = Stream.of(mentoring.getDate())
-                .toList();
+        String[] dates = mentoring.getDate().split(",");
         return AppliedMentoringInfo.builder()
                 .mentoringId(mentoring.getMentoringId())
                 .dates(dates)
@@ -27,8 +26,7 @@ public class MentoringMapper {
     }
     public static AppliedMentoringInfo mapToWaitingOrDoneAppliedInfo(Mentoring mentoring) {
         Senior senior = mentoring.getSenior();
-        List<String> dates = Stream.of(mentoring.getDate())
-                .toList();
+        String[] dates = mentoring.getDate().split(",");
         return AppliedMentoringInfo.builder()
                 .mentoringId(mentoring.getMentoringId())
                 .dates(dates)

--- a/src/main/java/com/postgraduate/domain/mentoring/application/mapper/MentoringMapper.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/mapper/MentoringMapper.java
@@ -1,5 +1,6 @@
 package com.postgraduate.domain.mentoring.application.mapper;
 
+import com.postgraduate.domain.mentoring.application.dto.AppliedMentoringDetailResponse;
 import com.postgraduate.domain.mentoring.application.dto.AppliedMentoringInfo;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.senior.domain.entity.Senior;
@@ -8,7 +9,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 public class MentoringMapper {
-    public static AppliedMentoringInfo mapToExpectedInfo(Mentoring mentoring) {
+    public static AppliedMentoringInfo mapToExpectedAppliedInfo(Mentoring mentoring) {
         Senior senior = mentoring.getSenior();
         List<String> dates = Stream.of(mentoring.getDate())
                 .toList();
@@ -24,7 +25,7 @@ public class MentoringMapper {
                 .chatLink(senior.getChatLink())
                 .build();
     }
-    public static AppliedMentoringInfo mapToWaitingOrDoneMentoringInfo(Mentoring mentoring) {
+    public static AppliedMentoringInfo mapToWaitingOrDoneAppliedInfo(Mentoring mentoring) {
         Senior senior = mentoring.getSenior();
         List<String> dates = Stream.of(mentoring.getDate())
                 .toList();
@@ -38,6 +39,21 @@ public class MentoringMapper {
                 .lab(senior.getLab())
                 .professor(senior.getProfessor())
                 .field(senior.getField())
+                .build();
+    }
+    public static AppliedMentoringDetailResponse mapToAppliedDetailInfo(Mentoring mentoring) {
+        Senior senior = mentoring.getSenior();
+        List<String> dates = Stream.of(mentoring.getDate())
+                .toList();
+        return AppliedMentoringDetailResponse.builder()
+                .seniorId(senior.getSeniorId())
+                .nickName(senior.getUser().getNickName())
+                .field(senior.getField())
+                .lab(senior.getLab())
+                .professor(senior.getProfessor())
+                .topic(mentoring.getTopic())
+                .question(mentoring.getQuestion())
+                .dates(dates)
                 .build();
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/application/mapper/MentoringMapper.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/mapper/MentoringMapper.java
@@ -1,6 +1,6 @@
 package com.postgraduate.domain.mentoring.application.mapper;
 
-import com.postgraduate.domain.mentoring.application.dto.MentoringInfo;
+import com.postgraduate.domain.mentoring.application.dto.AppliedMentoringInfo;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 
@@ -8,26 +8,27 @@ import java.util.List;
 import java.util.stream.Stream;
 
 public class MentoringMapper {
-    public static MentoringInfo mapToExpectedInfo(Mentoring mentoring) {
+    public static AppliedMentoringInfo mapToExpectedInfo(Mentoring mentoring) {
         Senior senior = mentoring.getSenior();
         List<String> dates = Stream.of(mentoring.getDate())
                 .toList();
-        return MentoringInfo.builder()
+        return AppliedMentoringInfo.builder()
                 .mentoringId(mentoring.getMentoringId())
                 .dates(dates)
                 .seniorId(senior.getSeniorId())
                 .nickName(senior.getUser().getNickName())
                 .postgradu(senior.getPostgradu())
                 .lab(senior.getLab())
+                .professor(senior.getProfessor())
                 .field(senior.getField())
                 .chatLink(senior.getChatLink())
                 .build();
     }
-    public static MentoringInfo mapToWaitingOrDoneMentoringInfo(Mentoring mentoring) {
+    public static AppliedMentoringInfo mapToWaitingOrDoneMentoringInfo(Mentoring mentoring) {
         Senior senior = mentoring.getSenior();
         List<String> dates = Stream.of(mentoring.getDate())
                 .toList();
-        return MentoringInfo.builder()
+        return AppliedMentoringInfo.builder()
                 .mentoringId(mentoring.getMentoringId())
                 .dates(dates)
                 .term(senior.getTerm())
@@ -35,6 +36,7 @@ public class MentoringMapper {
                 .nickName(senior.getUser().getNickName())
                 .postgradu(senior.getPostgradu())
                 .lab(senior.getLab())
+                .professor(senior.getProfessor())
                 .field(senior.getField())
                 .build();
     }

--- a/src/main/java/com/postgraduate/domain/mentoring/application/mapper/MentoringMapper.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/mapper/MentoringMapper.java
@@ -1,0 +1,41 @@
+package com.postgraduate.domain.mentoring.application.mapper;
+
+import com.postgraduate.domain.mentoring.application.dto.MentoringInfo;
+import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
+import com.postgraduate.domain.senior.domain.entity.Senior;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class MentoringMapper {
+    public static MentoringInfo mapToExpectedInfo(Mentoring mentoring) {
+        Senior senior = mentoring.getSenior();
+        List<String> dates = Stream.of(mentoring.getDate())
+                .toList();
+        return MentoringInfo.builder()
+                .mentoringId(mentoring.getMentoringId())
+                .dates(dates)
+                .seniorId(senior.getSeniorId())
+                .nickName(senior.getUser().getNickName())
+                .postgradu(senior.getPostgradu())
+                .lab(senior.getLab())
+                .field(senior.getField())
+                .chatLink(senior.getChatLink())
+                .build();
+    }
+    public static MentoringInfo mapToWaitingOrDoneMentoringInfo(Mentoring mentoring) {
+        Senior senior = mentoring.getSenior();
+        List<String> dates = Stream.of(mentoring.getDate())
+                .toList();
+        return MentoringInfo.builder()
+                .mentoringId(mentoring.getMentoringId())
+                .dates(dates)
+                .term(senior.getTerm())
+                .seniorId(senior.getSeniorId())
+                .nickName(senior.getUser().getNickName())
+                .postgradu(senior.getPostgradu())
+                .lab(senior.getLab())
+                .field(senior.getField())
+                .build();
+    }
+}

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringInfoUseCase.java
@@ -1,0 +1,57 @@
+package com.postgraduate.domain.mentoring.application.usecase;
+
+import com.postgraduate.domain.mentoring.application.dto.AppliedMentoringResponse;
+import com.postgraduate.domain.mentoring.application.dto.MentoringInfo;
+import com.postgraduate.domain.mentoring.application.mapper.MentoringMapper;
+import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
+import com.postgraduate.domain.mentoring.domain.entity.constant.Status;
+import com.postgraduate.domain.mentoring.domain.service.MentoringGetService;
+import com.postgraduate.domain.user.domain.entity.User;
+import com.postgraduate.domain.user.domain.repository.UserRepository;
+import com.postgraduate.global.auth.AuthDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MentoringInfoUseCase {
+    private final MentoringGetService mentoringGetService;
+
+    /**
+     * securityUtils 이후 수정
+     */
+    private final UserRepository userRepository;
+
+    public AppliedMentoringResponse getMentorings(Status status, AuthDetails authDetails) {
+        Long userId = authDetails.getUserId();
+        User user = userRepository.findById(userId).get();
+
+        List<Mentoring> mentorings = mentoringGetService.mentoringByUser(user, status);
+        return getCategories(status, mentorings);
+    }
+
+    private AppliedMentoringResponse getCategories(Status status, List<Mentoring> mentorings) {
+        List<MentoringInfo> mentoringInfos = new ArrayList<>();
+
+        switch (status) {
+            case WAITING, DONE -> {
+                for (Mentoring mentoring : mentorings) {
+                    mentoringInfos.add(MentoringMapper.mapToWaitingOrDoneMentoringInfo(mentoring));
+                }
+                return new AppliedMentoringResponse(mentoringInfos);
+            }
+
+            default -> {
+                for (Mentoring mentoring : mentorings) {
+                    mentoringInfos.add(MentoringMapper.mapToExpectedInfo(mentoring));
+                }
+                return new AppliedMentoringResponse(mentoringInfos);
+            }
+        }
+    }
+}

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringInfoUseCase.java
@@ -1,14 +1,15 @@
 package com.postgraduate.domain.mentoring.application.usecase;
 
+import com.postgraduate.domain.mentoring.application.dto.AppliedMentoringDetailResponse;
 import com.postgraduate.domain.mentoring.application.dto.AppliedMentoringResponse;
-import com.postgraduate.domain.mentoring.application.dto.MentoringInfo;
+import com.postgraduate.domain.mentoring.application.dto.AppliedMentoringInfo;
 import com.postgraduate.domain.mentoring.application.mapper.MentoringMapper;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.mentoring.domain.entity.constant.Status;
 import com.postgraduate.domain.mentoring.domain.service.MentoringGetService;
 import com.postgraduate.domain.user.domain.entity.User;
-import com.postgraduate.domain.user.domain.repository.UserRepository;
 import com.postgraduate.global.auth.AuthDetails;
+import com.postgraduate.global.config.security.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,33 +26,38 @@ public class MentoringInfoUseCase {
     /**
      * securityUtils 이후 수정
      */
-    private final UserRepository userRepository;
+    private final SecurityUtils securityUtils;
 
     public AppliedMentoringResponse getMentorings(Status status, AuthDetails authDetails) {
-        Long userId = authDetails.getUserId();
-        User user = userRepository.findById(userId).get();
+        User user = securityUtils.getLoggedInUser(authDetails);
 
         List<Mentoring> mentorings = mentoringGetService.mentoringByUser(user, status);
         return getCategories(status, mentorings);
     }
 
     private AppliedMentoringResponse getCategories(Status status, List<Mentoring> mentorings) {
-        List<MentoringInfo> mentoringInfos = new ArrayList<>();
+        List<AppliedMentoringInfo> appliedMentoringInfos = new ArrayList<>();
 
         switch (status) {
             case WAITING, DONE -> {
                 for (Mentoring mentoring : mentorings) {
-                    mentoringInfos.add(MentoringMapper.mapToWaitingOrDoneMentoringInfo(mentoring));
+                    appliedMentoringInfos.add(MentoringMapper.mapToWaitingOrDoneAppliedInfo(mentoring));
                 }
-                return new AppliedMentoringResponse(mentoringInfos);
+                return new AppliedMentoringResponse(appliedMentoringInfos);
             }
 
             default -> {
                 for (Mentoring mentoring : mentorings) {
-                    mentoringInfos.add(MentoringMapper.mapToExpectedInfo(mentoring));
+                    appliedMentoringInfos.add(MentoringMapper.mapToExpectedAppliedInfo(mentoring));
                 }
-                return new AppliedMentoringResponse(mentoringInfos);
+                return new AppliedMentoringResponse(appliedMentoringInfos);
             }
         }
+    }
+
+    public AppliedMentoringDetailResponse getMentoringDetail(Long mentoringId) {
+        Mentoring mentoring = mentoringGetService.mentoringDetail(mentoringId);
+        AppliedMentoringDetailResponse appliedMentoringDetailResponse = MentoringMapper.mapToAppliedDetailInfo(mentoring);
+        return appliedMentoringDetailResponse;
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/entity/Mentoring.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/entity/Mentoring.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Entity
 @Builder

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/entity/Mentoring.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/entity/Mentoring.java
@@ -31,7 +31,7 @@ public class Mentoring {
     @Column(nullable = false)
     private String question;
     @Column(nullable = false)
-    private LocalDateTime date;
+    private String date;
     @Column(nullable = false)
     private int pay;
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/entity/Mentoring.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/entity/Mentoring.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Builder
@@ -21,16 +22,16 @@ public class Mentoring {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long mentoringId;
-    @OneToOne
+    @ManyToOne
     private User user;
-    @OneToOne
+    @ManyToOne
     private Senior senior;
     @Column(nullable = false)
     private String topic;
     @Column(nullable = false)
     private String question;
     @Column(nullable = false)
-    private String date;
+    private LocalDateTime date;
     @Column(nullable = false)
     private int pay;
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
@@ -1,0 +1,13 @@
+package com.postgraduate.domain.mentoring.domain.repository;
+
+import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
+import com.postgraduate.domain.mentoring.domain.entity.constant.Status;
+import com.postgraduate.domain.user.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
+    Optional<List<Mentoring>> findAllByUserAndStatus(User user, Status status);
+}

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
@@ -21,7 +21,7 @@ public class MentoringGetService {
         return mentorings;
     }
 
-    public void mentoringDetail(Long mentoringId) {
-        mentoringRepository.findById(mentoringId).orElseThrow();
+    public Mentoring mentoringDetail(Long mentoringId) {
+        return mentoringRepository.findById(mentoringId).orElseThrow();
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
@@ -1,0 +1,27 @@
+package com.postgraduate.domain.mentoring.domain.service;
+
+import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
+import com.postgraduate.domain.mentoring.domain.entity.constant.Status;
+import com.postgraduate.domain.mentoring.domain.repository.MentoringRepository;
+import com.postgraduate.domain.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MentoringGetService {
+    private final MentoringRepository mentoringRepository;
+
+    public List<Mentoring> mentoringByUser(User user, Status status) {
+        List<Mentoring> mentorings =
+                mentoringRepository.findAllByUserAndStatus(user, status).orElse(new ArrayList<>());
+        return mentorings;
+    }
+
+    public void mentoringDetail(Long mentoringId) {
+        mentoringRepository.findById(mentoringId).orElseThrow();
+    }
+}

--- a/src/main/java/com/postgraduate/domain/mentoring/presentation/MentoringController.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/presentation/MentoringController.java
@@ -1,0 +1,31 @@
+package com.postgraduate.domain.mentoring.presentation;
+
+import com.postgraduate.domain.mentoring.application.dto.AppliedMentoringResponse;
+import com.postgraduate.domain.mentoring.application.usecase.MentoringInfoUseCase;
+import com.postgraduate.domain.mentoring.domain.entity.constant.Status;
+import com.postgraduate.global.auth.AuthDetails;
+import com.postgraduate.global.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import static com.postgraduate.domain.mentoring.presentation.constant.MentoringResponseMessage.GET_MENTORING_LIST_INFO;
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("mentoring")
+@Tag(name = "MENTORING Controller")
+public class MentoringController {
+    private final MentoringInfoUseCase infoUsecase;
+
+    @GetMapping("/me/{status}")
+    @Operation(description = "대학생 신청 멘토링 조회")
+    public ResponseDto<AppliedMentoringResponse> getMentoringInfos(@PathVariable Status status, @AuthenticationPrincipal AuthDetails authDetails) {
+        AppliedMentoringResponse mentoringResponse = infoUsecase.getMentorings(status, authDetails);
+        return ResponseDto.create(OK.value(), GET_MENTORING_LIST_INFO.getMessage(), mentoringResponse);
+    }
+}

--- a/src/main/java/com/postgraduate/domain/mentoring/presentation/MentoringController.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/presentation/MentoringController.java
@@ -1,5 +1,6 @@
 package com.postgraduate.domain.mentoring.presentation;
 
+import com.postgraduate.domain.mentoring.application.dto.AppliedMentoringDetailResponse;
 import com.postgraduate.domain.mentoring.application.dto.AppliedMentoringResponse;
 import com.postgraduate.domain.mentoring.application.usecase.MentoringInfoUseCase;
 import com.postgraduate.domain.mentoring.domain.entity.constant.Status;
@@ -8,7 +9,6 @@ import com.postgraduate.global.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,10 +22,17 @@ import static org.springframework.http.HttpStatus.OK;
 public class MentoringController {
     private final MentoringInfoUseCase infoUsecase;
 
-    @GetMapping("/me/{status}")
+    @GetMapping("/me")
     @Operation(description = "대학생 신청 멘토링 조회")
-    public ResponseDto<AppliedMentoringResponse> getMentoringInfos(@PathVariable Status status, @AuthenticationPrincipal AuthDetails authDetails) {
+    public ResponseDto<AppliedMentoringResponse> getMentoringInfos(@RequestParam Status status, @AuthenticationPrincipal AuthDetails authDetails) {
         AppliedMentoringResponse mentoringResponse = infoUsecase.getMentorings(status, authDetails);
         return ResponseDto.create(OK.value(), GET_MENTORING_LIST_INFO.getMessage(), mentoringResponse);
+    }
+
+    @GetMapping("/me/{mentoringId}")
+    @Operation(description = "대학생 신청 멘토링 상세조회")
+    public ResponseDto<AppliedMentoringDetailResponse> getMentoringDetails(@PathVariable Long mentoringId) {
+        AppliedMentoringDetailResponse mentoringDetail = infoUsecase.getMentoringDetail(mentoringId);
+        return ResponseDto.create(OK.value(), GET_MENTORING_LIST_INFO.getMessage(), mentoringDetail);
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/presentation/MentoringController.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/presentation/MentoringController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import static com.postgraduate.domain.mentoring.presentation.constant.MentoringResponseMessage.GET_MENTORING_DETAIL_INFO;
 import static com.postgraduate.domain.mentoring.presentation.constant.MentoringResponseMessage.GET_MENTORING_LIST_INFO;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -31,8 +32,8 @@ public class MentoringController {
 
     @GetMapping("/me/{mentoringId}")
     @Operation(description = "대학생 신청 멘토링 상세조회")
-    public ResponseDto<AppliedMentoringDetailResponse> getMentoringDetails(@PathVariable Long mentoringId) {
+    public ResponseDto<AppliedMentoringDetailResponse> getMentoringDetail(@PathVariable Long mentoringId) {
         AppliedMentoringDetailResponse mentoringDetail = infoUsecase.getMentoringDetail(mentoringId);
-        return ResponseDto.create(OK.value(), GET_MENTORING_LIST_INFO.getMessage(), mentoringDetail);
+        return ResponseDto.create(OK.value(), GET_MENTORING_DETAIL_INFO.getMessage(), mentoringDetail);
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/presentation/constant/MentoringResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/presentation/constant/MentoringResponseMessage.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MentoringResponseMessage {
-    GET_MENTORING_LIST_INFO("멘토링 리스트 조회에 성공하였습니다.");
+    GET_MENTORING_LIST_INFO("멘토링 리스트 조회에 성공하였습니다."),
+    GET_MENTORING_DETAIL_INFO("멘토링 상세 조회에 성공하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/presentation/constant/MentoringResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/presentation/constant/MentoringResponseMessage.java
@@ -1,0 +1,12 @@
+package com.postgraduate.domain.mentoring.presentation.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MentoringResponseMessage {
+    GET_MENTORING_LIST_INFO("멘토링 리스트 조회에 성공하였습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/postgraduate/domain/review/domain/entity/Review.java
+++ b/src/main/java/com/postgraduate/domain/review/domain/entity/Review.java
@@ -7,7 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 

--- a/src/main/java/com/postgraduate/domain/senior/domain/entity/Senior.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/entity/Senior.java
@@ -28,6 +28,8 @@ public class Senior {
     @Column(nullable = false)
     private String postgradu;
     @Column(nullable = false)
+    private String professor;
+    @Column(nullable = false)
     private String lab;
     @Column(nullable = false)
     private String field;

--- a/src/main/java/com/postgraduate/domain/senior/domain/entity/Senior.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/entity/Senior.java
@@ -41,6 +41,10 @@ public class Senior {
     private String time;
     @Column(nullable = false)
     private int term;
+    @Column(nullable = false)
+    private String account;
+    @Column(nullable = false)
+    private String bank;
     private String certification;
     @Column(nullable = false)
     private boolean status;

--- a/src/main/java/com/postgraduate/domain/senior/domain/entity/Senior.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/entity/Senior.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Builder
@@ -51,6 +50,5 @@ public class Senior {
     @Column(nullable = false)
     private boolean status;
     @Column(nullable = false)
-    @ColumnDefault("0")
     private int hit;
 }

--- a/src/main/java/com/postgraduate/domain/user/application/dto/req/UserNickNameRequest.java
+++ b/src/main/java/com/postgraduate/domain/user/application/dto/req/UserNickNameRequest.java
@@ -1,0 +1,12 @@
+package com.postgraduate.domain.user.application.dto.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserNickNameRequest {
+    private String nickName;
+}

--- a/src/main/java/com/postgraduate/domain/user/application/dto/res/UserInfoResponse.java
+++ b/src/main/java/com/postgraduate/domain/user/application/dto/res/UserInfoResponse.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class UserInfoResponse {
     private String nickName;
-    private String bank;
-    private String account;
+    private String profile;
     private int point;
 }

--- a/src/main/java/com/postgraduate/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/postgraduate/domain/user/application/mapper/UserMapper.java
@@ -7,8 +7,7 @@ public class UserMapper {
     public static UserInfoResponse mapToInfo(User user) {
         return UserInfoResponse.builder()
                 .nickName(user.getNickName())
-                .account(user.getAccount())
-                .bank(user.getBank())
+                .profile(user.getProfile())
                 .point(user.getPoint())
                 .build();
     }

--- a/src/main/java/com/postgraduate/domain/user/application/usecase/UserMyPageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/user/application/usecase/UserMyPageUseCase.java
@@ -4,6 +4,9 @@ import com.postgraduate.domain.user.application.dto.res.UserInfoResponse;
 import com.postgraduate.domain.user.application.mapper.UserMapper;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.service.UserGetService;
+import com.postgraduate.domain.user.domain.service.UserUpdateService;
+import com.postgraduate.global.auth.AuthDetails;
+import com.postgraduate.global.config.security.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,14 +15,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class UserMyPageUseCase {
-    private final UserGetService userGetService;
+    private final SecurityUtils securityUtils;
+    private final UserUpdateService userUpdateService;
 
-    public UserInfoResponse getUserInfo() {
-        Long userId = 1l;
-        /**
-         * securityUtils 만들어서 사용
-         */
-        User user = userGetService.getUser(userId);
+    public UserInfoResponse getUserInfo(AuthDetails authDetails) {
+        User user = securityUtils.getLoggedInUser(authDetails);
         return UserMapper.mapToInfo(user);
+    }
+
+    public void updateUser(AuthDetails authDetails, String nickName) {
+        User user = securityUtils.getLoggedInUser(authDetails);
+        userUpdateService.updateNickName(user.getUserId(), nickName);
     }
 }

--- a/src/main/java/com/postgraduate/domain/user/domain/entity/User.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/entity/User.java
@@ -23,7 +23,7 @@ public class User {
     @Column(nullable = false, unique = true)
     private Long socialId;
 
-    @Column(unique = true)
+//    @Column(unique = true) email은 여러 소셜을 사용하면 unique가 깨질 수 있음
     private String email;
 
     @Column(unique = true)
@@ -47,4 +47,8 @@ public class User {
 
     @UpdateTimestamp
     private LocalDate updatedAt;
+
+    public void updateNickName(String nickName) {
+        this.nickName = nickName;
+    }
 }

--- a/src/main/java/com/postgraduate/domain/user/domain/entity/User.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/entity/User.java
@@ -6,13 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.*;
 
 import java.time.LocalDate;
 
-@Entity(name = "user")
+@Entity
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -32,11 +30,10 @@ public class User {
     private String nickName;
 
     @Column(nullable = false)
-    @ColumnDefault("default") //이후에 기본 이미지 생기면 수정이 필요할 듯
-    private String profile;
+    @Builder.Default //이후에 기본 이미지 생기면 수정이 필요할 듯
+    private String profile = "default";
 
     @Column(nullable = false)
-    @ColumnDefault("0")
     private int point;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/postgraduate/domain/user/domain/entity/User.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/entity/User.java
@@ -32,12 +32,12 @@ public class User {
     private String nickName;
 
     @Column(nullable = false)
+    @ColumnDefault("default") //이후에 기본 이미지 생기면 수정이 필요할 듯
+    private String profile;
+
+    @Column(nullable = false)
     @ColumnDefault("0")
     private int point;
-
-    private String account;
-
-    private String bank;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/postgraduate/domain/user/domain/service/UserUpdateService.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/service/UserUpdateService.java
@@ -1,0 +1,17 @@
+package com.postgraduate.domain.user.domain.service;
+
+import com.postgraduate.domain.user.domain.entity.User;
+import com.postgraduate.domain.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserUpdateService {
+    private final UserRepository userRepository;
+
+    public void updateNickName(Long userId, String nickName) {
+        User user = userRepository.findById(userId).get();
+        user.updateNickName(nickName);
+    }
+}

--- a/src/main/java/com/postgraduate/domain/user/presentation/UserController.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/UserController.java
@@ -1,16 +1,18 @@
 package com.postgraduate.domain.user.presentation;
 
+import com.postgraduate.domain.user.application.dto.req.UserNickNameRequest;
 import com.postgraduate.domain.user.application.dto.res.UserInfoResponse;
 import com.postgraduate.domain.user.application.usecase.UserMyPageUseCase;
+import com.postgraduate.global.auth.AuthDetails;
 import com.postgraduate.global.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import static com.postgraduate.domain.user.presentation.constant.UserResponseMessage.GET_USER_INFO;
+import static com.postgraduate.domain.user.presentation.constant.UserResponseMessage.UPDATE_USER_INFO;
 import static org.springframework.http.HttpStatus.OK;
 
 @RestController
@@ -22,8 +24,15 @@ public class UserController {
 
     @GetMapping("/me")
     @Operation(description = "사용자 기본 정보 조회 - 닉네임, 은행, 계좌, 포인트")
-    public ResponseDto<UserInfoResponse> getUserInfo() {
-        UserInfoResponse userInfo = myPageUseCase.getUserInfo();
+    public ResponseDto<UserInfoResponse> getUserInfo(@AuthenticationPrincipal AuthDetails authDetails) {
+        UserInfoResponse userInfo = myPageUseCase.getUserInfo(authDetails);
         return ResponseDto.create(OK.value(), GET_USER_INFO.getMessage(), userInfo);
+    }
+
+    @PostMapping("/nickname")
+    @Operation(description = "사용자 닉네임 변경 및 업데이트")
+    public ResponseDto updateNickName(@AuthenticationPrincipal AuthDetails authDetails, @RequestBody UserNickNameRequest userNickNameRequest) {
+        myPageUseCase.updateUser(authDetails, userNickNameRequest.getNickName());
+        return ResponseDto.create(OK.value(), UPDATE_USER_INFO.getMessage());
     }
 }

--- a/src/main/java/com/postgraduate/domain/user/presentation/UserController.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
         return ResponseDto.create(OK.value(), GET_USER_INFO.getMessage(), userInfo);
     }
 
-    @PostMapping("/nickname")
+    @PatchMapping("/nickname")
     @Operation(description = "사용자 닉네임 변경 및 업데이트")
     public ResponseDto updateNickName(@AuthenticationPrincipal AuthDetails authDetails, @RequestBody UserNickNameRequest userNickNameRequest) {
         myPageUseCase.updateUser(authDetails, userNickNameRequest.getNickName());

--- a/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseMessage.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum UserResponseMessage {
-    GET_USER_INFO("사용자 기본 정보 조회에 성공하였습니다.");
+    GET_USER_INFO("사용자 기본 정보 조회에 성공하였습니다."),
+    UPDATE_USER_INFO("사용자 업데이트에 성공하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/postgraduate/global/config/security/util/SecurityUtils.java
+++ b/src/main/java/com/postgraduate/global/config/security/util/SecurityUtils.java
@@ -1,16 +1,17 @@
 package com.postgraduate.global.config.security.util;
 
 import com.postgraduate.domain.user.domain.entity.User;
+import com.postgraduate.domain.user.domain.repository.UserRepository;
+import com.postgraduate.global.auth.AuthDetails;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
-
 @Component
+@RequiredArgsConstructor
 public class SecurityUtils {
-
-//    public Optional<User> getLoggedInUser() {
-//        return Optional.ofNullable(
-//                ((PrincipalDetails) (SecurityContextHolder.getContext().getAuthentication()).getPrincipal()).getUser());
-//    }
+    private final UserRepository userRepository;
+    public User getLoggedInUser(AuthDetails authDetails) {
+        return userRepository.findById(authDetails.getUserId()).orElseThrow();
+    }
 
 }


### PR DESCRIPTION
## 🦝 PR 요약
멘토링 관련 작업 + 대학생 마이페이지

## ✨ PR 상세 내용
엔티티 수정, 멘토링과 마이페이지의 분리로 인해 멘토링 작업 중단 이후 대학생 마이페이지 해당 작업
User 계좌, 은행 삭제 및 프로필 사진 추가
Senior 계좌, 은행, 교수님 추가
신청한 멘토링 조회 - 각 상태별
신청한 멘토링 상세 조회
유저 마이페이지 상단 노출용 정보 조회
유저 닉네임 수정 및 등록

## 🚨 주의 사항
요구사항 수정에 따른 테이블 수정해서 몇가지 정보 수정됨

## ✅ 체크 리스트
- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
