### PR TITLE
RAC-97 refactor : 사용자 정의 응답 코드 생성

### DIFF
--- a/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
@@ -37,7 +37,7 @@ public class AuthController {
             return ResponseDto.create(AUTH_CONTINUE.getCode(), NOT_REGISTERED_USER_MESSAGE.getMessage(), authUser);
         }
         JwtTokenResponse jwtToken = jwtUseCase.signIn(authUser.getUser());
-        return ResponseDto.create(AUTH_ALREADY.getCode(), SUCCESS_AUTH_MESSAGE.getMessage(), jwtToken);
+        return ResponseDto.create(AUTH_NONE.getCode(), SUCCESS_AUTH_MESSAGE.getMessage(), jwtToken);
     }
 
     @PostMapping("/signup")

--- a/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
@@ -18,8 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.postgraduate.domain.auth.presentation.contant.AuthResponseCode.*;
 import static com.postgraduate.domain.auth.presentation.contant.AuthResponseMessage.*;
-import static org.springframework.http.HttpStatus.OK;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,10 +34,10 @@ public class AuthController {
     public ResponseDto<?> getUserDetails(@RequestBody KakaoLoginRequest request) {
         AuthUserResponse authUser = kakaoSignInUseCase.getUser(request.getAccessToken());
         if (authUser.getSocialId() != null) {
-            return ResponseDto.create(OK.value(), NOT_REGISTERED_USER_MESSAGE.getMessage(), authUser);
+            return ResponseDto.create(AUTH_CONTINUE.getCode(), NOT_REGISTERED_USER_MESSAGE.getMessage(), authUser);
         }
         JwtTokenResponse jwtToken = jwtUseCase.signIn(authUser.getUser());
-        return ResponseDto.create(OK.value(), SUCCESS_AUTH_MESSAGE.getMessage(), jwtToken);
+        return ResponseDto.create(AUTH_ALREADY.getCode(), SUCCESS_AUTH_MESSAGE.getMessage(), jwtToken);
     }
 
     @PostMapping("/signup")
@@ -45,13 +45,13 @@ public class AuthController {
     public ResponseDto<JwtTokenResponse> signUpUser(@RequestBody SignUpRequest request) {
         AuthUserResponse authUser = kakaoSignInUseCase.signUp(request);
         JwtTokenResponse jwtToken = jwtUseCase.signIn(authUser.getUser());
-        return ResponseDto.create(OK.value(), SUCCESS_AUTH_MESSAGE.getMessage(), jwtToken);
+        return ResponseDto.create(AUTH_CREATE.getCode(), SUCCESS_AUTH_MESSAGE.getMessage(), jwtToken);
     }
 
     @PostMapping("/refresh")
     @Operation(summary = "토큰 재발급", description = "refreshToken 으로 토큰 재발급")
     public ResponseDto<JwtTokenResponse> refresh(@AuthenticationPrincipal AuthDetails authDetails, HttpServletRequest request) {
         JwtTokenResponse jwtToken = jwtUseCase.regenerateToken(authDetails, request);
-        return ResponseDto.create(OK.value(), SUCCESS_REGENERATE_TOKEN_MESSAGE.getMessage(), jwtToken);
+        return ResponseDto.create(AUTH_UPDATE.getCode(), SUCCESS_REGENERATE_TOKEN_MESSAGE.getMessage(), jwtToken);
     }
 }

--- a/src/main/java/com/postgraduate/domain/auth/presentation/contant/AuthResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/contant/AuthResponseCode.java
@@ -1,0 +1,16 @@
+package com.postgraduate.domain.auth.presentation.contant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthResponseCode {
+    AUTH_FIND("AU200"),
+    AUTH_UPDATE("AU201"),
+    AUTH_CREATE("AU202"),
+    AUTH_DELETE("AU203"),
+    AUTH_ALREADY("AU204"),
+    AUTH_CONTINUE("AU205");
+    private final String code;
+}

--- a/src/main/java/com/postgraduate/domain/auth/presentation/contant/AuthResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/contant/AuthResponseCode.java
@@ -11,6 +11,6 @@ public enum AuthResponseCode {
     AUTH_CREATE("AU202"),
     AUTH_DELETE("AU203"),
     AUTH_ALREADY("AU204"),
-    AUTH_CONTINUE("AU205");
+    AUTH_NONE("AU205");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/presentation/MentoringController.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/presentation/MentoringController.java
@@ -4,6 +4,7 @@ import com.postgraduate.domain.mentoring.application.dto.AppliedMentoringDetailR
 import com.postgraduate.domain.mentoring.application.dto.AppliedMentoringResponse;
 import com.postgraduate.domain.mentoring.application.usecase.MentoringInfoUseCase;
 import com.postgraduate.domain.mentoring.domain.entity.constant.Status;
+import com.postgraduate.domain.mentoring.presentation.constant.MentoringResponseCode;
 import com.postgraduate.global.auth.AuthDetails;
 import com.postgraduate.global.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import static com.postgraduate.domain.mentoring.presentation.constant.MentoringResponseCode.MENTORING_FIND;
 import static com.postgraduate.domain.mentoring.presentation.constant.MentoringResponseMessage.GET_MENTORING_DETAIL_INFO;
 import static com.postgraduate.domain.mentoring.presentation.constant.MentoringResponseMessage.GET_MENTORING_LIST_INFO;
 import static org.springframework.http.HttpStatus.OK;
@@ -27,13 +29,13 @@ public class MentoringController {
     @Operation(description = "대학생 신청 멘토링 조회")
     public ResponseDto<AppliedMentoringResponse> getMentoringInfos(@RequestParam Status status, @AuthenticationPrincipal AuthDetails authDetails) {
         AppliedMentoringResponse mentoringResponse = infoUsecase.getMentorings(status, authDetails);
-        return ResponseDto.create(OK.value(), GET_MENTORING_LIST_INFO.getMessage(), mentoringResponse);
+        return ResponseDto.create(MENTORING_FIND.getCode(), GET_MENTORING_LIST_INFO.getMessage(), mentoringResponse);
     }
 
     @GetMapping("/me/{mentoringId}")
     @Operation(description = "대학생 신청 멘토링 상세조회")
     public ResponseDto<AppliedMentoringDetailResponse> getMentoringDetail(@PathVariable Long mentoringId) {
         AppliedMentoringDetailResponse mentoringDetail = infoUsecase.getMentoringDetail(mentoringId);
-        return ResponseDto.create(OK.value(), GET_MENTORING_DETAIL_INFO.getMessage(), mentoringDetail);
+        return ResponseDto.create(MENTORING_FIND.getCode(), GET_MENTORING_DETAIL_INFO.getMessage(), mentoringDetail);
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/presentation/constant/MentoringResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/presentation/constant/MentoringResponseCode.java
@@ -1,0 +1,14 @@
+package com.postgraduate.domain.mentoring.presentation.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum MentoringResponseCode {
+    MENTORING_FIND("MT200"),
+    MENTORING_UPDATE("MT201"),
+    MENTORING_CREATE("MT202"),
+    MENTORING_DELETE("MT203");
+    private final String code;
+}

--- a/src/main/java/com/postgraduate/domain/payment/presentation/constant/PaymentResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/payment/presentation/constant/PaymentResponseCode.java
@@ -1,0 +1,14 @@
+package com.postgraduate.domain.payment.presentation.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum PaymentResponseCode {
+    PAYMENT_FIND("PM200"),
+    PAYMENT_UPDATE("PM201"),
+    PAYMENT_CREATE("PM202"),
+    PAYMENT_DELETE("PM203");
+    private final String code;
+}

--- a/src/main/java/com/postgraduate/domain/review/presentation/constant/ReviewResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/review/presentation/constant/ReviewResponseCode.java
@@ -1,0 +1,14 @@
+package com.postgraduate.domain.review.presentation.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ReviewResponseCode {
+    REVIEW_FIND("RV200"),
+    REVIEW_UPDATE("RV201"),
+    REVIEW_CREATE("RV202"),
+    REVIEW_DELETE("RV203");
+    private final String code;
+}

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -4,6 +4,7 @@ import com.postgraduate.domain.senior.application.dto.req.SeniorProfileRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorSignUpRequest;
 import com.postgraduate.domain.senior.application.usecase.SeniorSignUpUseCase;
 import com.postgraduate.domain.senior.application.usecase.SeniorUpdateUseCase;
+import com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode;
 import com.postgraduate.global.auth.AuthDetails;
 import com.postgraduate.global.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode.SENIOR_CREATE;
 import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseMessage.SUCCESS_SENIOR_SIGN_UP_MESSAGE;
 import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseMessage.SUCCESS_UPDATE_PROFILE_MESSAGE;
 import static org.springframework.http.HttpStatus.OK;
@@ -30,7 +32,7 @@ public class SeniorController {
     public ResponseDto singUpSenior(@AuthenticationPrincipal AuthDetails authDetails,
                                        @RequestBody SeniorSignUpRequest request) {
         signUpUseCase.signUp(authDetails, request);
-        return ResponseDto.create(OK.value(), SUCCESS_SENIOR_SIGN_UP_MESSAGE.getMessage());
+        return ResponseDto.create(SENIOR_CREATE.getCode(), SUCCESS_SENIOR_SIGN_UP_MESSAGE.getMessage());
     }
 
     @PatchMapping("/profile")
@@ -38,6 +40,6 @@ public class SeniorController {
     public ResponseDto singUpSenior(@AuthenticationPrincipal AuthDetails authDetails,
                                        @RequestBody SeniorProfileRequest request) {
         updateUseCase.updateProfile(authDetails, request);
-        return ResponseDto.create(OK.value(), SUCCESS_UPDATE_PROFILE_MESSAGE.getMessage());
+        return ResponseDto.create(SENIOR_CREATE.getCode(), SUCCESS_UPDATE_PROFILE_MESSAGE.getMessage());
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseCode.java
@@ -1,0 +1,14 @@
+package com.postgraduate.domain.senior.presentation.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum SeniorResponseCode {
+    SENIOR_FIND("SNR200"),
+    SENIOR_UPDATE("SNR201"),
+    SENIOR_CREATE("SNR202"),
+    SENIOR_DELETE("SNR203");
+    private final String code;
+}

--- a/src/main/java/com/postgraduate/domain/user/presentation/UserController.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/UserController.java
@@ -3,6 +3,7 @@ package com.postgraduate.domain.user.presentation;
 import com.postgraduate.domain.user.application.dto.req.UserNickNameRequest;
 import com.postgraduate.domain.user.application.dto.res.UserInfoResponse;
 import com.postgraduate.domain.user.application.usecase.UserMyPageUseCase;
+import com.postgraduate.domain.user.presentation.constant.UserResponseCode;
 import com.postgraduate.global.auth.AuthDetails;
 import com.postgraduate.global.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import static com.postgraduate.domain.user.presentation.constant.UserResponseCode.USER_FIND;
+import static com.postgraduate.domain.user.presentation.constant.UserResponseCode.USER_UPDATE;
 import static com.postgraduate.domain.user.presentation.constant.UserResponseMessage.*;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -25,20 +28,20 @@ public class UserController {
     @Operation(description = "사용자 기본 정보 조회 - 닉네임, 프로필, 포인트")
     public ResponseDto<UserInfoResponse> getUserInfo(@AuthenticationPrincipal AuthDetails authDetails) {
         UserInfoResponse userInfo = myPageUseCase.getUserInfo(authDetails);
-        return ResponseDto.create(OK.value(), GET_USER_INFO.getMessage(), userInfo);
+        return ResponseDto.create(USER_FIND.getCode(), GET_USER_INFO.getMessage(), userInfo);
     }
 
     @PatchMapping("/nickname")
     @Operation(description = "사용자 닉네임 변경 및 업데이트")
     public ResponseDto updateNickName(@AuthenticationPrincipal AuthDetails authDetails, @RequestBody UserNickNameRequest userNickNameRequest) {
         myPageUseCase.updateUser(authDetails, userNickNameRequest.getNickName());
-        return ResponseDto.create(OK.value(), UPDATE_USER_INFO.getMessage());
+        return ResponseDto.create(USER_UPDATE.getCode(), UPDATE_USER_INFO.getMessage());
     }
 
     @GetMapping("/nickname")
     @Operation(description = "사용자 닉네임 중복체크")
     public ResponseDto<Boolean> duplicatedNickName(@RequestParam String nickName) {
         boolean checkDup = myPageUseCase.duplicatedNickName(nickName);
-        return ResponseDto.create(OK.value(), GET_NICKNAME_CHECK.getMessage(), checkDup);
+        return ResponseDto.create(USER_FIND.getCode(), GET_NICKNAME_CHECK.getMessage(), checkDup);
     }
 }

--- a/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseCode.java
@@ -1,0 +1,14 @@
+package com.postgraduate.domain.user.presentation.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum UserResponseCode {
+    USER_FIND("UR200"),
+    USER_UPDATE("UR201"),
+    USER_CREATE("UR202"),
+    USER_DELETE("UR203");
+    private final String code;
+}

--- a/src/main/java/com/postgraduate/global/dto/ErrorResponse.java
+++ b/src/main/java/com/postgraduate/global/dto/ErrorResponse.java
@@ -1,0 +1,17 @@
+package com.postgraduate.global.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+@Getter
+@RequiredArgsConstructor
+public class ErrorResponse {
+    private String errorCode;
+    private String message;
+
+    public ErrorResponse(String errorCode, String message) {
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/postgraduate/global/dto/ResponseDto.java
+++ b/src/main/java/com/postgraduate/global/dto/ResponseDto.java
@@ -10,14 +10,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL) //Json 결과에서 Null은 빼고 나타남
 public class ResponseDto<T> {
-    private int code;
+    private String code;
     private String message;
     private T data;
 
-    public static <T> ResponseDto<T> create(int code, String message) {
+    public static <T> ResponseDto<T> create(String code, String message) {
         return new ResponseDto(code, message, null);
     }
-    public static <T> ResponseDto<T> create(int code, String message, T dto) {
+    public static <T> ResponseDto<T> create(String code, String message, T dto) {
         return new ResponseDto(code, message, dto);
     }
 }

--- a/src/main/java/com/postgraduate/global/exception/ApplicationException.java
+++ b/src/main/java/com/postgraduate/global/exception/ApplicationException.java
@@ -1,0 +1,16 @@
+package com.postgraduate.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public abstract class ApplicationException extends RuntimeException{
+    private final String errorCode;
+    private final HttpStatus httpStatus;
+
+    protected ApplicationException(String message, String errorCode, HttpStatus httpStatus) {
+        super(message);
+        this.errorCode = errorCode;
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/com/postgraduate/global/jwt/JwtProvider.java
+++ b/src/main/java/com/postgraduate/global/jwt/JwtProvider.java
@@ -54,7 +54,7 @@ public class JwtProvider {
                 .setExpiration(Date.from(refreshDate))
                 .signWith(SignatureAlgorithm.HS256, secret)
                 .compact();
-        redisRepository.setValues(REFRESH + id, refreshToken, Duration.ofDays(30));
+        redisRepository.setValues(REFRESH + id, refreshToken, Duration.ofSeconds(refreshExpiration));
         return refreshToken;
     }
 
@@ -73,8 +73,10 @@ public class JwtProvider {
             parseClaims(token);
         } catch (SignatureException | UnsupportedJwtException | IllegalArgumentException | MalformedJwtException e) {
             //TODO: 유효하지 않은 토큰 예외
+            throw new IllegalArgumentException();
         } catch (ExpiredJwtException e) {
             //TODO: 만료된 토큰 예외
+            throw new IllegalArgumentException();
         }
     }
 
@@ -86,11 +88,7 @@ public class JwtProvider {
     }
 
     public Claims parseClaims(String token) {
-        try {
-            JwtParser parser = Jwts.parser().setSigningKey(secret);
-            return parser.parseClaimsJws(token).getBody();
-        } catch (ExpiredJwtException e) {
-            return e.getClaims();
-        }
+        JwtParser parser = Jwts.parser().setSigningKey(secret);
+        return parser.parseClaimsJws(token).getBody();
     }
 }


### PR DESCRIPTION
## 🦝 PR 요약
- 사용자 정의 응답 코드 생성
- 토큰 예외 관련 부분 수정

## ✨ PR 상세 내용
모든 Entity에 맞춰 응답 코드를 만들고, 컨트롤러, `ResponseDto` 수정
`JwtProvider`에서 `validateToken`에서 예외를 잡아도 다른 처리를 하지 않아서 만료된 토큰도 모두 동작해서 우선 `IllegalArgumentException` 던지도록 변경
`parseClaim`에서 `ExpiredJwtException` 발생시 claim을 반환하도록 되어있는데, 해당 부분 삭제함
혹시 의도한 내용이라면 다시 되돌리겠음

## 🚨 주의 사항
HTTP 상태코드가 원래 정의되어 있고, 그 값 이외에 사용자 정의 코드를 사용하는 것이 맞는가 논의를 해볼 필요 있음
다만, ResponseDto 외에 기본으로 HTTP 상태코드는 전송이 되기 때문에 오히려 포함하면 2개의 동일한 상태코드가 가는 것이 아닌가 싶기도 함
ResponseDto에는 사용자 정의 코드를 포함시켜도 문제가 없을 듯 하여 우선 추가함

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
