### PR TITLE
RAC-129 feat : 도메인 관련 예외 처리

### DIFF
--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/kakao/KakaoSignInUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/kakao/KakaoSignInUseCase.java
@@ -16,13 +16,13 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class KakaoSignInUseCase {
     private final KakaoAccessTokenUseCase kakaoTokenUseCase;
     private final UserSaveService userSaveService;
     private final UserGetService userGetService;
 
-    @Transactional
     public AuthUserResponse getUser(KakaoCodeRequest codeRequest) {
         KakaoUserInfoResponse userInfo = kakaoTokenUseCase.getKakaoToken(codeRequest.getCode());
         Long socialId = userInfo.getId();

--- a/src/main/java/com/postgraduate/domain/auth/exception/KakaoException.java
+++ b/src/main/java/com/postgraduate/domain/auth/exception/KakaoException.java
@@ -1,0 +1,10 @@
+package com.postgraduate.domain.auth.exception;
+
+import static com.postgraduate.domain.auth.presentation.contant.AuthResponseCode.AUTH_INVALID_KAKAO;
+import static com.postgraduate.domain.auth.presentation.contant.AuthResponseMessage.KAKAO_INVALID_MESSAGE;
+
+public class KakaoException extends AuthException{
+    public KakaoException() {
+        super(KAKAO_INVALID_MESSAGE.getMessage(), AUTH_INVALID_KAKAO.getCode());
+    }
+}

--- a/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
@@ -32,8 +32,8 @@ public class AuthController {
 
     @PostMapping("/login")
     @Operation(summary = "카카오 로그인", description = "회원인 경우 JWT를, 회원이 아닌 경우 socialId를 반환합니다(회원가입은 진행하지 않습니다).")
-    public ResponseDto<?> authLogin(@RequestBody KakaoCodeRequest tokenRequest) {
-        AuthUserResponse authUser = kakaoSignInUseCase.getUser(tokenRequest);
+    public ResponseDto<?> authLogin(@RequestBody KakaoCodeRequest request) {
+        AuthUserResponse authUser = kakaoSignInUseCase.getUser(request);
         if (authUser.getUser().isEmpty())
             return ResponseDto.create(AUTH_NONE.getCode(), NOT_REGISTERED_USER_MESSAGE.getMessage(), authUser);
         JwtTokenResponse jwtToken = jwtUseCase.signIn(authUser.getUser().get());

--- a/src/main/java/com/postgraduate/domain/auth/presentation/contant/AuthResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/contant/AuthResponseCode.java
@@ -12,7 +12,7 @@ public enum AuthResponseCode {
     AUTH_DELETE("AU203"),
     AUTH_ALREADY("AU204"),
 
-    AUTH_NONE("AU900"),
-    AUTH_INVALID_KAKAO("AU901");
+    AUTH_NONE("EX900"),
+    AUTH_INVALID_KAKAO("EX901");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/auth/presentation/contant/AuthResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/contant/AuthResponseCode.java
@@ -11,6 +11,8 @@ public enum AuthResponseCode {
     AUTH_CREATE("AU202"),
     AUTH_DELETE("AU203"),
     AUTH_ALREADY("AU204"),
-    AUTH_NONE("AU205");
+
+    AUTH_NONE("AU900"),
+    AUTH_INVALID_KAKAO("AU901");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/auth/presentation/contant/AuthResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/contant/AuthResponseMessage.java
@@ -10,6 +10,7 @@ public enum AuthResponseMessage {
     NOT_REGISTERED_USER_MESSAGE("가입하지 않은 유저입니다."),
     SUCCESS_REGENERATE_TOKEN_MESSAGE("토큰 재발급에 성공하였습니다."),
 
-    PERMISSION_DENIED_MESSAGE("권한이 없습니다.");
+    PERMISSION_DENIED_MESSAGE("권한이 없습니다."),
+    KAKAO_INVALID_MESSAGE("카카오 정보가 유효하지 않습니다.");
     private final String message;
 }

--- a/src/main/java/com/postgraduate/domain/image/application/usecase/PreSignedUseCase.java
+++ b/src/main/java/com/postgraduate/domain/image/application/usecase/PreSignedUseCase.java
@@ -2,6 +2,7 @@ package com.postgraduate.domain.image.application.usecase;
 
 import com.postgraduate.domain.image.application.dto.PreSignedUrlRequest;
 import com.postgraduate.domain.image.application.dto.PreSignedUrlResponse;
+import com.postgraduate.domain.image.exception.EmptyFileException;
 import com.postgraduate.global.config.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,14 +14,14 @@ public class PreSignedUseCase {
 
     public PreSignedUrlResponse getProfileUrl(PreSignedUrlRequest preSignedUrlRequest) {
         if (preSignedUrlRequest.getFileName().isEmpty())
-            throw new IllegalArgumentException(); //TODO : 빈값이 들어올 경우 예외 처리
+            throw new EmptyFileException();
         String preSignedUrl = s3Service.getProfilePreSignedUrl(preSignedUrlRequest.getFileName());
         return new PreSignedUrlResponse(preSignedUrl);
     }
 
     public PreSignedUrlResponse getCertificationUrl(PreSignedUrlRequest preSignedUrlRequest) {
         if (preSignedUrlRequest.getFileName().isEmpty())
-            throw new IllegalArgumentException(); //TODO : 빈값이 들어올 경우 예외 처리
+            throw new EmptyFileException();
         String preSignedUrl = s3Service.getCertificationPreSignedUrl(preSignedUrlRequest.getFileName());
         return new PreSignedUrlResponse(preSignedUrl);
     }

--- a/src/main/java/com/postgraduate/domain/image/exception/EmptyFileException.java
+++ b/src/main/java/com/postgraduate/domain/image/exception/EmptyFileException.java
@@ -1,0 +1,10 @@
+package com.postgraduate.domain.image.exception;
+
+import static com.postgraduate.domain.image.presentation.constant.ImageResponseCode.IMAGE_EMPTY;
+import static com.postgraduate.domain.image.presentation.constant.ImageResponseMessage.EMPTY_IMAGE;
+
+public class EmptyFileException extends ImageException{
+    public EmptyFileException() {
+        super(EMPTY_IMAGE.getMessage(), IMAGE_EMPTY.getCode());
+    }
+}

--- a/src/main/java/com/postgraduate/domain/image/exception/ImageException.java
+++ b/src/main/java/com/postgraduate/domain/image/exception/ImageException.java
@@ -1,0 +1,9 @@
+package com.postgraduate.domain.image.exception;
+
+import com.postgraduate.global.exception.ApplicationException;
+
+public class ImageException extends ApplicationException {
+    protected ImageException(String message, String errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/com/postgraduate/domain/image/presentation/constant/ImageResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/image/presentation/constant/ImageResponseCode.java
@@ -11,6 +11,6 @@ public enum ImageResponseCode {
     IMAGE_CREATE("IMG202"),
     IMAGE_DELETE("IMG203"),
 
-    IMAGE_EMPTY("IMG800");
+    IMAGE_EMPTY("EX800");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/image/presentation/constant/ImageResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/image/presentation/constant/ImageResponseCode.java
@@ -9,6 +9,8 @@ public enum ImageResponseCode {
     IMAGE_FIND("IMG200"),
     IMAGE_UPDATE("IMG201"),
     IMAGE_CREATE("IMG202"),
-    IMAGE_DELETE("IMG203");
+    IMAGE_DELETE("IMG203"),
+
+    IMAGE_EMPTY("IMG800");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/image/presentation/constant/ImageResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/image/presentation/constant/ImageResponseMessage.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ImageResponseMessage {
-    ISSUE_URL("URL발급에 성공하였습니다.");
+    ISSUE_URL("URL발급에 성공하였습니다."),
+
+    EMPTY_IMAGE("이미지 파일이 입력되지 않았습니다.");
     private final String message;
 }

--- a/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorGetService.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorGetService.java
@@ -2,6 +2,7 @@ package com.postgraduate.domain.senior.domain.service;
 
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.repository.SeniorRepository;
+import com.postgraduate.domain.senior.exception.NoneSeniorException;
 import com.postgraduate.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,10 +13,10 @@ public class SeniorGetService {
     private final SeniorRepository seniorRepository;
 
     public Senior byUser(User user) {
-        return seniorRepository.findByUser(user).orElseThrow(/**예외 처리**/);
+        return seniorRepository.findByUser(user).orElseThrow(NoneSeniorException::new);
     }
 
     public Senior bySeniorId(Long seniorId) {
-        return seniorRepository.findById(seniorId).orElseThrow(/**예외 처리**/);
+        return seniorRepository.findById(seniorId).orElseThrow(NoneSeniorException::new);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/exception/NoneSeniorException.java
+++ b/src/main/java/com/postgraduate/domain/senior/exception/NoneSeniorException.java
@@ -1,0 +1,10 @@
+package com.postgraduate.domain.senior.exception;
+
+import com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode;
+import com.postgraduate.domain.senior.presentation.constant.SeniorResponseMessage;
+
+public class NoneSeniorException extends SeniorException{
+    public NoneSeniorException() {
+        super(SeniorResponseMessage.NONE_SENIOR.getMessage(), SeniorResponseCode.NONE_SENIOR.getCode());
+    }
+}

--- a/src/main/java/com/postgraduate/domain/senior/exception/SeniorException.java
+++ b/src/main/java/com/postgraduate/domain/senior/exception/SeniorException.java
@@ -1,0 +1,9 @@
+package com.postgraduate.domain.senior.exception;
+
+import com.postgraduate.global.exception.ApplicationException;
+
+public class SeniorException extends ApplicationException {
+    protected SeniorException(String message, String errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseCode.java
@@ -9,6 +9,8 @@ public enum SeniorResponseCode {
     SENIOR_FIND("SNR200"),
     SENIOR_UPDATE("SNR201"),
     SENIOR_CREATE("SNR202"),
-    SENIOR_DELETE("SNR203");
+    SENIOR_DELETE("SNR203"),
+
+    NONE_SENIOR("SNR400");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseCode.java
@@ -11,6 +11,6 @@ public enum SeniorResponseCode {
     SENIOR_CREATE("SNR202"),
     SENIOR_DELETE("SNR203"),
 
-    NONE_SENIOR("SNR400");
+    NONE_SENIOR("EX400");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseMessage.java
@@ -10,7 +10,9 @@ public enum SeniorResponseMessage {
     UPDATE_PROFILE("대학원생 프로필 등록에 성공하였습니다"),
     GET_SENIOR_INFO("대학원생 정보 조회에 성공하였습니다"),
     GET_SENIOR_PROFILE("대학원생 프로필 조회에 성공하였습니다"),
-    UPDATE_CERTIFICATION("대학원생 인증사진 업로드에 성공하였습니다");
+    UPDATE_CERTIFICATION("대학원생 인증사진 업로드에 성공하였습니다"),
+
+    NONE_SENIOR("등록된 멘토가 없습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/postgraduate/domain/user/application/exception/NoneUserException.java
+++ b/src/main/java/com/postgraduate/domain/user/application/exception/NoneUserException.java
@@ -1,0 +1,10 @@
+package com.postgraduate.domain.user.application.exception;
+
+import com.postgraduate.domain.user.presentation.constant.UserResponseCode;
+import com.postgraduate.domain.user.presentation.constant.UserResponseMessage;
+
+public class NoneUserException extends UserException{
+    public NoneUserException() {
+        super(UserResponseMessage.NONE_USER.getMessage(), UserResponseCode.NONE_USER.getCode());
+    }
+}

--- a/src/main/java/com/postgraduate/domain/user/application/exception/UserException.java
+++ b/src/main/java/com/postgraduate/domain/user/application/exception/UserException.java
@@ -1,0 +1,9 @@
+package com.postgraduate.domain.user.application.exception;
+
+import com.postgraduate.global.exception.ApplicationException;
+
+public class UserException extends ApplicationException {
+    protected UserException(String message, String errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/com/postgraduate/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/service/UserGetService.java
@@ -1,5 +1,6 @@
 package com.postgraduate.domain.user.domain.service;
 
+import com.postgraduate.domain.user.application.exception.NoneUserException;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +14,7 @@ public class UserGetService {
     private final UserRepository userRepository;
 
     public User getUser(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(/**예외 처리**/);
+        User user = userRepository.findById(userId).orElseThrow(NoneUserException::new);
         return user;
     }
 

--- a/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseCode.java
@@ -9,6 +9,8 @@ public enum UserResponseCode {
     USER_FIND("UR200"),
     USER_UPDATE("UR201"),
     USER_CREATE("UR202"),
-    USER_DELETE("UR203");
+    USER_DELETE("UR203"),
+
+    NONE_USER("EX300");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseMessage.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 public enum UserResponseMessage {
     GET_USER_INFO("사용자 기본 정보 조회에 성공하였습니다."),
     GET_NICKNAME_CHECK("닉네임 중복체크에 성공하였습니다."),
-    UPDATE_USER_INFO("사용자 업데이트에 성공하였습니다.");
+    UPDATE_USER_INFO("사용자 업데이트에 성공하였습니다."),
+
+    NONE_USER("등록된 사용자가 없습니다.");
 
     private final String message;
 }


### PR DESCRIPTION
## 🦝 PR 요약
도메인 관련 예외 처리

## ✨ PR 상세 내용
Auth, Image, Senior, User 우선 구현된 부분에서 예외처리 추가

## 🚨 주의 사항
KakaoAccessUseCase에서 WebClient에서 발생하는 예외를 잡기 위해서 Try-Catch가 좀 많이 사용됐는데, 이 방법 말고 더 효율적인 방법이 있다면 추천해주세요!

## ✅ 체크 리스트
- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
