### PR TITLE
RAC-157 feat: 대학원생 마이페이지 정산 조회

### DIFF
--- a/src/main/java/com/postgraduate/PostgraduateApplication.java
+++ b/src/main/java/com/postgraduate/PostgraduateApplication.java
@@ -2,7 +2,9 @@ package com.postgraduate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class PostgraduateApplication {
 

--- a/src/main/java/com/postgraduate/domain/account/application/mapper/AccountMapper.java
+++ b/src/main/java/com/postgraduate/domain/account/application/mapper/AccountMapper.java
@@ -5,14 +5,14 @@ import com.postgraduate.domain.senior.application.dto.req.SeniorAccountRequest;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 
 public class AccountMapper {
-    public static Account mapToAccount(Senior senior, SeniorAccountRequest accountRequest) {
+    public static Account mapToAccount(Senior senior, SeniorAccountRequest accountRequest, String accountNumber, String rrn) {
         return Account.builder()
                 .senior(senior)
-                .accountNumber(accountRequest.getAccountNumber())
+                .accountNumber(accountNumber)
                 .accountHolder(accountRequest.getAccountHolder())
                 .bank(accountRequest.getBank())
                 .name(accountRequest.getName())
-                .rrn(accountRequest.getRrn())
+                .rrn(rrn)
                 .build();
     }
 }

--- a/src/main/java/com/postgraduate/domain/auth/presentation/contant/AuthResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/contant/AuthResponseCode.java
@@ -15,6 +15,7 @@ public enum AuthResponseCode {
 
     AUTH_DENIED("EX900"),
     AUTH_INVALID_KAKAO("EX901"),
-    AUTH_KAKAO_CODE("EX902");
+    AUTH_KAKAO_CODE("EX902"),
+    AUTH_FAILED("EX903");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/auth/presentation/contant/AuthResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/contant/AuthResponseMessage.java
@@ -12,6 +12,7 @@ public enum AuthResponseMessage {
 
     PERMISSION_DENIED("권한이 없습니다."),
     KAKAO_INVALID("카카오 정보가 유효하지 않습니다."),
-    KAKAO_CODE("카카오 코드가 유효하지 않습니다.");
+    KAKAO_CODE("카카오 코드가 유효하지 않습니다."),
+    FAILED_AUTH("사용자 인증에 실패했습니다.");
     private final String message;
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/application/dto/DoneSeniorMentoringInfo.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/dto/DoneSeniorMentoringInfo.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -13,6 +15,6 @@ public class DoneSeniorMentoringInfo {
     private String nickname;
     private int term;
     private String date;
-    private String month;
+    private LocalDate salaryDate;
     private Boolean status;
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/application/mapper/MentoringMapper.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/mapper/MentoringMapper.java
@@ -5,6 +5,7 @@ import com.postgraduate.domain.mentoring.application.dto.req.MentoringApplyReque
 import com.postgraduate.domain.mentoring.application.dto.res.AppliedMentoringDetailResponse;
 import com.postgraduate.domain.mentoring.application.dto.res.SeniorMentoringDetailResponse;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
+import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
 
@@ -99,15 +100,15 @@ public class MentoringMapper {
                 .build();
     }
 
-    public static DoneSeniorMentoringInfo mapToSeniorDoneInfo(Mentoring mentoring, String month, Boolean status) {
+    public static DoneSeniorMentoringInfo mapToSeniorDoneInfo(Mentoring mentoring, Salary salary) {
         return DoneSeniorMentoringInfo.builder()
                 .mentoringId(mentoring.getMentoringId())
                 .profile(mentoring.getUser().getProfile())
                 .nickname(mentoring.getUser().getNickName())
                 .date(mentoring.getDate())
                 .term(mentoring.getSenior().getProfile().getTerm())
-                .month(month)
-                .status(status)
+                .salaryDate(salary.getSalaryDate())
+                .status(salary.getStatus())
                 .build();
     }
 

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCase.java
@@ -18,19 +18,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.text.SimpleDateFormat;
 import java.time.Duration;
-import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import static com.postgraduate.domain.mentoring.application.mapper.MentoringMapper.*;
-import static com.postgraduate.domain.mentoring.application.mapper.MentoringMapper.mapToSeniorDoneInfo;
 import static com.postgraduate.domain.mentoring.domain.entity.constant.Status.*;
-import static com.postgraduate.domain.salary.util.MonthFormat.getMonthFormat;
 
 @Service
 @Transactional
@@ -89,15 +83,8 @@ public class MentoringSeniorInfoUseCase {
     private AppliedMentoringResponse getSeniorDone(List<Mentoring> mentorings) {
         List<DoneSeniorMentoringInfo> doneMentoringInfos = new ArrayList<>();
         for (Mentoring mentoring : mentorings) {
-            LocalDate updatedAt = mentoring.getUpdatedAt();
-            String month = updatedAt.format(getMonthFormat());
-            Salary salary = salaryGetService.bySeniorAndMonth(mentoring.getSenior(), month)
-                            .orElseThrow();
-            doneMentoringInfos.add(mapToSeniorDoneInfo(mentoring, mentoring.getDate(), salary.getStatus()));
-            //todo : 정산 관련 로직 필요, 예외 처리 필요
-            /**
-             * 우선 yyyy-MM 형식으로 저장
-             */
+            Salary salary = salaryGetService.byMentoring(mentoring);
+            doneMentoringInfos.add(mapToSeniorDoneInfo(mentoring, salary));
         }
         return new AppliedMentoringResponse(doneMentoringInfos);
     }

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
@@ -6,6 +6,7 @@ import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,5 +14,5 @@ public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
     Optional<Mentoring> findByMentoringId(Long mentoringId);
     List<Mentoring> findAllByUserAndStatus(User user, Status status);
     List<Mentoring> findAllBySeniorAndStatus(Senior senior, Status status);
-//    Optional<List<Mentoring>> findAllByDeletedAtIsNull();
+    List<Mentoring> findAllByStatusAndCreatedAtIsBefore(Status status, LocalDate now);
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
     Optional<Mentoring> findByMentoringId(Long mentoringId);
-    Optional<List<Mentoring>> findAllByUserAndStatus(User user, Status status);
-    Optional<List<Mentoring>> findAllBySeniorAndStatus(Senior senior, Status status);
+    List<Mentoring> findAllByUserAndStatus(User user, Status status);
+    List<Mentoring> findAllBySeniorAndStatus(Senior senior, Status status);
 //    Optional<List<Mentoring>> findAllByDeletedAtIsNull();
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
@@ -9,6 +9,7 @@ import com.postgraduate.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +30,7 @@ public class MentoringGetService {
         return mentoringRepository.findByMentoringId(mentoringId).orElseThrow(MentoringNotFoundException::new);
     }
 
-//    public List<Mentoring> all() {
-//        return mentoringRepository.findAllByDeletedAtIsNull().orElse(new ArrayList<>());
-//    }
+    public List<Mentoring> byStatusAndCreatedAt(Status status, LocalDate now) {
+        return mentoringRepository.findAllByStatusAndCreatedAtIsBefore(status, now);
+    }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 
 @Service

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
@@ -18,11 +18,11 @@ public class MentoringGetService {
     private final MentoringRepository mentoringRepository;
 
     public List<Mentoring> mentoringByUser(User user, Status status) {
-        return mentoringRepository.findAllByUserAndStatus(user, status).orElse(new ArrayList<>());
+        return mentoringRepository.findAllByUserAndStatus(user, status);
     }
 
     public List<Mentoring> mentoringBySenior(Senior senior, Status status) {
-        return mentoringRepository.findAllBySeniorAndStatus(senior, status).orElse(new ArrayList<>());
+        return mentoringRepository.findAllBySeniorAndStatus(senior, status);
     }
 
     public Mentoring byMentoringId(Long mentoringId) {

--- a/src/main/java/com/postgraduate/domain/salary/application/dto/res/SalaryDetailResponse.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/dto/res/SalaryDetailResponse.java
@@ -14,6 +14,6 @@ public class SalaryDetailResponse {
     private String nickName;
     private String date;
     private int term;
-    private int pay;
+    private int salaryAmount;
     private LocalDate salaryDate;
 }

--- a/src/main/java/com/postgraduate/domain/salary/application/dto/res/SalaryDetailResponse.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/dto/res/SalaryDetailResponse.java
@@ -1,0 +1,19 @@
+package com.postgraduate.domain.salary.application.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SalaryDetailResponse {
+    private String profile;
+    private String nickName;
+    private String date;
+    private int term;
+    private int pay;
+    private LocalDate salaryDate;
+}

--- a/src/main/java/com/postgraduate/domain/salary/application/dto/res/SalaryInfoResponse.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/dto/res/SalaryInfoResponse.java
@@ -11,5 +11,5 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class SalaryInfoResponse {
     private LocalDate salaryDate;
-    private int pay;
+    private int salaryAmount;
 }

--- a/src/main/java/com/postgraduate/domain/salary/application/dto/res/SalaryInfoResponse.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/dto/res/SalaryInfoResponse.java
@@ -1,0 +1,15 @@
+package com.postgraduate.domain.salary.application.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SalaryInfoResponse {
+    private LocalDate salaryDate;
+    private int pay;
+}

--- a/src/main/java/com/postgraduate/domain/salary/application/mapper/SalaryMapper.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/mapper/SalaryMapper.java
@@ -21,7 +21,7 @@ public class SalaryMapper {
                 .nickName(salary.getMentoring().getUser().getNickName())
                 .date(salary.getMentoring().getDate())
                 .term(salary.getSenior().getProfile().getTerm())
-                .pay(salary.getMentoring().getPay()) //TODO 수수료
+                .salaryAmount(salary.getMentoring().getPay()) //TODO 수수료
                 .salaryDate(salary.getSalaryDate())
                 .build();
     }

--- a/src/main/java/com/postgraduate/domain/salary/application/mapper/SalaryMapper.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/mapper/SalaryMapper.java
@@ -1,13 +1,28 @@
 package com.postgraduate.domain.salary.application.mapper;
 
+import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
+import com.postgraduate.domain.salary.application.dto.res.SalaryDetailResponse;
 import com.postgraduate.domain.salary.domain.entity.Salary;
-import com.postgraduate.domain.senior.domain.entity.Senior;
+
+import java.time.LocalDate;
 
 public class SalaryMapper {
-    public static Salary mapToSalary(String month, Senior senior) {
+    public static Salary mapToSalary(Mentoring mentoring, LocalDate salaryDate) {
         return Salary.builder()
-                .month(month)
-                .senior(senior)
+                .senior(mentoring.getSenior())
+                .mentoring(mentoring)
+                .salaryDate(salaryDate)
+                .build();
+    }
+
+    public static SalaryDetailResponse mapToSalaryDetail(Salary salary) {
+        return SalaryDetailResponse.builder()
+                .profile(salary.getMentoring().getUser().getProfile())
+                .nickName(salary.getMentoring().getUser().getNickName())
+                .date(salary.getMentoring().getDate())
+                .term(salary.getSenior().getProfile().getTerm())
+                .pay(salary.getMentoring().getPay())
+                .salaryDate(salary.getSalaryDate())
                 .build();
     }
 }

--- a/src/main/java/com/postgraduate/domain/salary/application/mapper/SalaryMapper.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/mapper/SalaryMapper.java
@@ -21,7 +21,7 @@ public class SalaryMapper {
                 .nickName(salary.getMentoring().getUser().getNickName())
                 .date(salary.getMentoring().getDate())
                 .term(salary.getSenior().getProfile().getTerm())
-                .pay(salary.getMentoring().getPay())
+                .pay(salary.getMentoring().getPay()) //TODO 수수료
                 .salaryDate(salary.getSalaryDate())
                 .build();
     }

--- a/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryInfoUseCase.java
@@ -1,0 +1,53 @@
+package com.postgraduate.domain.salary.application.usecase;
+
+import com.postgraduate.domain.salary.application.dto.res.SalaryDetailResponse;
+import com.postgraduate.domain.salary.application.dto.res.SalaryInfoResponse;
+import com.postgraduate.domain.salary.application.mapper.SalaryMapper;
+import com.postgraduate.domain.salary.domain.entity.Salary;
+import com.postgraduate.domain.salary.domain.service.SalaryGetService;
+import com.postgraduate.domain.senior.domain.entity.Senior;
+import com.postgraduate.domain.senior.domain.service.SeniorGetService;
+import com.postgraduate.domain.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SalaryInfoUseCase {
+    private static final int SALARY_DATE = 10;
+    private final SeniorGetService seniorGetService;
+    private final SalaryGetService salaryGetService;
+
+    public SalaryInfoResponse getSalary(User user) {
+        Senior senior = seniorGetService.byUser(user);
+        LocalDate salaryDate = getSalaryDate();
+        List<Salary> salaries = salaryGetService.bySeniorAndSalaryDate(senior, salaryDate);
+        int amount = getAmount(salaries);
+        return new SalaryInfoResponse(salaryDate, amount); //TODO 수수료
+    }
+
+    private LocalDate getSalaryDate() {
+        LocalDate now = LocalDate.now();
+        return now.getDayOfMonth() <= SALARY_DATE
+                ? now.withDayOfMonth(SALARY_DATE)
+                : now.plusMonths(1).withDayOfMonth(SALARY_DATE);
+    }
+
+    private int getAmount(List<Salary> salaries) {
+        return salaries.stream()
+                .map(salary -> salary.getMentoring().getPay())
+                .mapToInt(Integer::intValue)
+                .sum();
+    }
+
+    public List<SalaryDetailResponse> getSalaryDetail(User user, Boolean status) {
+        Senior senior = seniorGetService.byUser(user);
+        List<Salary> salaries = salaryGetService.bySeniorAndStatus(senior, status);
+        return salaries.stream().map(SalaryMapper::mapToSalaryDetail).toList();
+    }
+}

--- a/src/main/java/com/postgraduate/domain/salary/domain/entity/Salary.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/entity/Salary.java
@@ -1,11 +1,14 @@
 package com.postgraduate.domain.salary.domain.entity;
 
+import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 
 @Entity
 @Builder
@@ -18,19 +21,15 @@ public class Salary {
     private Long salaryId;
 
     @Column(nullable = false)
-    private String month;
-
-    @Column(nullable = false)
-    private int amount;
-
-    @Column(nullable = false)
     @Builder.Default
     private Boolean status = false;
 
     @ManyToOne
     private Senior senior;
 
-    public void updateAmount(int amount) {
-        this.amount += (amount-4000);
-    }
+    @OneToOne
+    private Mentoring mentoring;
+
+    @Column(nullable = false)
+    private LocalDate salaryDate;
 }

--- a/src/main/java/com/postgraduate/domain/salary/domain/repository/SalaryRepository.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/repository/SalaryRepository.java
@@ -1,5 +1,6 @@
 package com.postgraduate.domain.salary.domain.repository;
 
+import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,5 @@ import java.util.Optional;
 public interface SalaryRepository extends JpaRepository<Salary, Long> {
     List<Salary> findAllBySeniorAndSalaryDate(Senior senior, LocalDate salaryDate);
     List<Salary> findAllBySeniorAndStatus(Senior senior, Boolean status);
+    Optional<Salary> findByMentoring(Mentoring mentoring);
 }

--- a/src/main/java/com/postgraduate/domain/salary/domain/repository/SalaryRepository.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/repository/SalaryRepository.java
@@ -4,8 +4,10 @@ import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface SalaryRepository extends JpaRepository<Salary, Long> {
-    Optional<Salary> findBySeniorAndMonth(Senior senior, String month);
+    List<Salary> findAllBySeniorAndSalaryDate(Senior senior, LocalDate salaryDate);
 }

--- a/src/main/java/com/postgraduate/domain/salary/domain/repository/SalaryRepository.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/repository/SalaryRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 
 public interface SalaryRepository extends JpaRepository<Salary, Long> {
     List<Salary> findAllBySeniorAndSalaryDate(Senior senior, LocalDate salaryDate);
+    List<Salary> findAllBySeniorAndStatus(Senior senior, Boolean status);
 }

--- a/src/main/java/com/postgraduate/domain/salary/domain/repository/SalaryRepository.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/repository/SalaryRepository.java
@@ -3,6 +3,7 @@ package com.postgraduate.domain.salary.domain.repository;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.senior.domain.entity.Senior;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -11,6 +12,6 @@ import java.util.Optional;
 
 public interface SalaryRepository extends JpaRepository<Salary, Long> {
     List<Salary> findAllBySeniorAndSalaryDate(Senior senior, LocalDate salaryDate);
-    List<Salary> findAllBySeniorAndStatus(Senior senior, Boolean status);
+    List<Salary> findAllBySeniorAndStatus(Senior senior, Boolean status, Sort sort);
     Optional<Salary> findByMentoring(Mentoring mentoring);
 }

--- a/src/main/java/com/postgraduate/domain/salary/domain/repository/SalaryRepository.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/repository/SalaryRepository.java
@@ -3,7 +3,6 @@ package com.postgraduate.domain.salary.domain.repository;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.senior.domain.entity.Senior;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -12,6 +11,6 @@ import java.util.Optional;
 
 public interface SalaryRepository extends JpaRepository<Salary, Long> {
     List<Salary> findAllBySeniorAndSalaryDate(Senior senior, LocalDate salaryDate);
-    List<Salary> findAllBySeniorAndStatus(Senior senior, Boolean status, Sort sort);
+    List<Salary> findAllBySeniorAndStatusOrderBySalaryDateDesc(Senior senior, Boolean status);
     Optional<Salary> findByMentoring(Mentoring mentoring);
 }

--- a/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryGetService.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryGetService.java
@@ -1,5 +1,6 @@
 package com.postgraduate.domain.salary.domain.service;
 
+import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.salary.domain.repository.SalaryRepository;
 import com.postgraduate.domain.senior.domain.entity.Senior;
@@ -20,5 +21,9 @@ public class SalaryGetService {
 
     public List<Salary> bySeniorAndSalaryDate(Senior senior, LocalDate salaryDate) {
         return salaryRepository.findAllBySeniorAndSalaryDate(senior, salaryDate);
+    }
+
+    public Salary byMentoring(Mentoring mentoring) {
+        return salaryRepository.findByMentoring(mentoring).orElseThrow(IllegalArgumentException::new);
     }
 }

--- a/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryGetService.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryGetService.java
@@ -6,14 +6,15 @@ import com.postgraduate.domain.senior.domain.entity.Senior;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
+import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class SalaryGetService {
     private final SalaryRepository salaryRepository;
 
-    public Optional<Salary> bySeniorAndMonth(Senior senior, String month) {
-        return salaryRepository.findBySeniorAndMonth(senior, month);
+    public List<Salary> bySeniorAndSalaryDate(Senior senior, LocalDate salaryDate) {
+        return salaryRepository.findAllBySeniorAndSalaryDate(senior, salaryDate);
     }
 }

--- a/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryGetService.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryGetService.java
@@ -3,6 +3,7 @@ package com.postgraduate.domain.salary.domain.service;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.salary.domain.repository.SalaryRepository;
+import com.postgraduate.domain.salary.exception.SalaryNotFoundException;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,6 @@ public class SalaryGetService {
     }
 
     public Salary byMentoring(Mentoring mentoring) {
-        return salaryRepository.findByMentoring(mentoring).orElseThrow(IllegalArgumentException::new);
+        return salaryRepository.findByMentoring(mentoring).orElseThrow(SalaryNotFoundException::new);
     }
 }

--- a/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryGetService.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryGetService.java
@@ -14,6 +14,10 @@ import java.util.List;
 public class SalaryGetService {
     private final SalaryRepository salaryRepository;
 
+    public List<Salary> bySeniorAndStatus(Senior senior, Boolean status) {
+        return salaryRepository.findAllBySeniorAndStatus(senior, status);
+    }
+
     public List<Salary> bySeniorAndSalaryDate(Senior senior, LocalDate salaryDate) {
         return salaryRepository.findAllBySeniorAndSalaryDate(senior, salaryDate);
     }

--- a/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryGetService.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryGetService.java
@@ -6,6 +6,7 @@ import com.postgraduate.domain.salary.domain.repository.SalaryRepository;
 import com.postgraduate.domain.salary.exception.SalaryNotFoundException;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -17,7 +18,8 @@ public class SalaryGetService {
     private final SalaryRepository salaryRepository;
 
     public List<Salary> bySeniorAndStatus(Senior senior, Boolean status) {
-        return salaryRepository.findAllBySeniorAndStatus(senior, status);
+        Sort sort = Sort.by(Sort.Direction.DESC, "salaryDate");
+        return salaryRepository.findAllBySeniorAndStatus(senior, status, sort);
     }
 
     public List<Salary> bySeniorAndSalaryDate(Senior senior, LocalDate salaryDate) {

--- a/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryGetService.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryGetService.java
@@ -6,7 +6,6 @@ import com.postgraduate.domain.salary.domain.repository.SalaryRepository;
 import com.postgraduate.domain.salary.exception.SalaryNotFoundException;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -18,8 +17,7 @@ public class SalaryGetService {
     private final SalaryRepository salaryRepository;
 
     public List<Salary> bySeniorAndStatus(Senior senior, Boolean status) {
-        Sort sort = Sort.by(Sort.Direction.DESC, "salaryDate");
-        return salaryRepository.findAllBySeniorAndStatus(senior, status, sort);
+        return salaryRepository.findAllBySeniorAndStatusOrderBySalaryDateDesc(senior, status);
     }
 
     public List<Salary> bySeniorAndSalaryDate(Senior senior, LocalDate salaryDate) {

--- a/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryUpdateService.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryUpdateService.java
@@ -1,14 +1,9 @@
 package com.postgraduate.domain.salary.domain.service;
 
-import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
-import com.postgraduate.domain.salary.domain.entity.Salary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class SalaryUpdateService {
-    public void updateAmount(Salary salary, Mentoring mentoring) {
-        salary.updateAmount(mentoring.getPay());
-    }
 }

--- a/src/main/java/com/postgraduate/domain/salary/exception/SalaryException.java
+++ b/src/main/java/com/postgraduate/domain/salary/exception/SalaryException.java
@@ -1,0 +1,10 @@
+package com.postgraduate.domain.salary.exception;
+
+import com.postgraduate.global.exception.ApplicationException;
+
+public class SalaryException extends ApplicationException {
+
+    protected SalaryException(String message, String errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/com/postgraduate/domain/salary/exception/SalaryNotFoundException.java
+++ b/src/main/java/com/postgraduate/domain/salary/exception/SalaryNotFoundException.java
@@ -1,0 +1,10 @@
+package com.postgraduate.domain.salary.exception;
+
+import static com.postgraduate.domain.salary.presentation.constant.SalaryResponseCode.SALARY_NOT_FOUND;
+import static com.postgraduate.domain.salary.presentation.constant.SalaryResponseMessage.NOT_FOUND_SALARY;
+
+public class SalaryNotFoundException extends SalaryException {
+    public SalaryNotFoundException() {
+        super(NOT_FOUND_SALARY.getMessage(), SALARY_NOT_FOUND.getCode());
+    }
+}

--- a/src/main/java/com/postgraduate/domain/salary/presentation/SalaryController.java
+++ b/src/main/java/com/postgraduate/domain/salary/presentation/SalaryController.java
@@ -1,0 +1,49 @@
+package com.postgraduate.domain.salary.presentation;
+
+import com.postgraduate.domain.salary.application.dto.res.SalaryDetailResponse;
+import com.postgraduate.domain.salary.application.dto.res.SalaryInfoResponse;
+import com.postgraduate.domain.salary.application.usecase.SalaryInfoUseCase;
+import com.postgraduate.domain.user.domain.entity.User;
+import com.postgraduate.global.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.postgraduate.domain.salary.presentation.constant.SalaryResponseCode.SALARY_FIND;
+import static com.postgraduate.domain.salary.presentation.constant.SalaryResponseMessage.GET_SALARY_INFO;
+import static com.postgraduate.domain.salary.presentation.constant.SalaryResponseMessage.GET_SALARY_LIST_INFO;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/salary")
+@Tag(name = "SALARY Controller")
+public class SalaryController {
+    private final SalaryInfoUseCase salaryInfoUseCase;
+
+    @GetMapping()
+    @Operation(summary = "대학원생 정산 예정액, 다음 정산 예정일 조회", description = "마이페이지에서 공통으로 보이는 정산 예정 정보입니다.")
+    public ResponseDto<SalaryInfoResponse> getSalary(@AuthenticationPrincipal User user) {
+        SalaryInfoResponse salary = salaryInfoUseCase.getSalary(user);
+        return ResponseDto.create(SALARY_FIND.getCode(), GET_SALARY_INFO.getMessage(), salary);
+    }
+
+    @GetMapping("/waiting")
+    @Operation(summary = "대학원생 정산예정 목록 조회", description = "정산 예정 탭에서 보이는 목록입니다.")
+    public ResponseDto<List<SalaryDetailResponse>> getWaitingSalary(@AuthenticationPrincipal User user) {
+        List<SalaryDetailResponse> salary = salaryInfoUseCase.getSalaryDetail(user, false);
+        return ResponseDto.create(SALARY_FIND.getCode(), GET_SALARY_LIST_INFO.getMessage(), salary);
+    }
+
+    @GetMapping("/done")
+    @Operation(summary = "대학원생 정산완료 목록 조회", description = "정산 완료 탭에서 보이는 목록입니다.")
+    public ResponseDto<List<SalaryDetailResponse>> getDoneSalary(@AuthenticationPrincipal User user) {
+        List<SalaryDetailResponse> salary = salaryInfoUseCase.getSalaryDetail(user, true);
+        return ResponseDto.create(SALARY_FIND.getCode(), GET_SALARY_LIST_INFO.getMessage(), salary);
+    }
+}

--- a/src/main/java/com/postgraduate/domain/salary/presentation/constant/SalaryResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/salary/presentation/constant/SalaryResponseCode.java
@@ -11,6 +11,6 @@ public enum SalaryResponseCode {
     SALARY_CREATE("SLR202"),
     SALARY_DELETE("SLR203"),
 
-    NONE_SALARY("EX500");
+    SALARY_NOT_FOUND("EX500");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/salary/presentation/constant/SalaryResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/salary/presentation/constant/SalaryResponseCode.java
@@ -1,0 +1,16 @@
+package com.postgraduate.domain.salary.presentation.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum SalaryResponseCode {
+    SALARY_FIND("SLR200"),
+    SALARY_UPDATE("SLR201"),
+    SALARY_CREATE("SLR202"),
+    SALARY_DELETE("SLR203"),
+
+    NONE_SALARY("EX500");
+    private final String code;
+}

--- a/src/main/java/com/postgraduate/domain/salary/presentation/constant/SalaryResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/salary/presentation/constant/SalaryResponseMessage.java
@@ -9,7 +9,7 @@ public enum SalaryResponseMessage {
     GET_SALARY_INFO("정산 정보 조회에 성공하였습니다"),
     GET_SALARY_LIST_INFO("정산 리스트 조회에 성공하였습니다."),
 
-    NONE_SALARY("정산을 찾을 수 없습니다.");
+    NOT_FOUND_SALARY("정산을 찾을 수 없습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/postgraduate/domain/salary/presentation/constant/SalaryResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/salary/presentation/constant/SalaryResponseMessage.java
@@ -1,0 +1,15 @@
+package com.postgraduate.domain.salary.presentation.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SalaryResponseMessage {
+    GET_SALARY_INFO("정산 정보 조회에 성공하였습니다"),
+    GET_SALARY_LIST_INFO("정산 리스트 조회에 성공하였습니다."),
+
+    NONE_SALARY("정산을 찾을 수 없습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorDetailResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorDetailResponse.java
@@ -1,0 +1,22 @@
+package com.postgraduate.domain.senior.application.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SeniorDetailResponse {
+    private String nickName;
+    private String profile;
+    private String postgradu;
+    private String major;
+    private String lab;
+    private String professor;
+    private String[] keyword;
+    private String info;
+    private String oneLiner;
+    private String target;
+    private String time;
+}

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorInfoResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorInfoResponse.java
@@ -11,8 +11,6 @@ import lombok.Getter;
 public class SeniorInfoResponse {
     private String nickName;
     private String profile;
-    private int amount;
-    private String month;
     private Status certificationRegister;
     private boolean profileRegister;
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorInfoResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorInfoResponse.java
@@ -1,6 +1,6 @@
 package com.postgraduate.domain.senior.application.dto.res;
 
-import com.postgraduate.domain.senior.domain.entity.constant.Status;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,8 +9,13 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class SeniorInfoResponse {
-    private String nickName;
     private String profile;
-    private Status certificationRegister;
-    private boolean profileRegister;
+    private String nickName;
+    private String lab;
+    private String keyword;
+    private String info;
+    private String target;
+    private String chatLink;
+    private String field;
+    private String oneLiner;
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorMyPageResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorMyPageResponse.java
@@ -11,8 +11,6 @@ import lombok.Getter;
 public class SeniorMyPageResponse {
     private String nickName;
     private String profile;
-    private int amount;
-    private String month;
     private Status certificationRegister;
     private boolean profileRegister;
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorMyPageResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorMyPageResponse.java
@@ -1,0 +1,18 @@
+package com.postgraduate.domain.senior.application.dto.res;
+
+import com.postgraduate.domain.senior.domain.entity.constant.Status;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class SeniorMyPageResponse {
+    private String nickName;
+    private String profile;
+    private int amount;
+    private String month;
+    private Status certificationRegister;
+    private boolean profileRegister;
+}

--- a/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
@@ -5,6 +5,7 @@ import com.postgraduate.domain.auth.application.dto.req.SeniorSignUpRequest;
 import com.postgraduate.domain.senior.application.dto.res.SeniorDetailResponse;
 import com.postgraduate.domain.senior.application.dto.req.SeniorProfileRequest;
 import com.postgraduate.domain.senior.application.dto.res.SeniorInfoResponse;
+import com.postgraduate.domain.senior.application.dto.res.SeniorMyPageResponse;
 import com.postgraduate.domain.senior.domain.entity.Info;
 import com.postgraduate.domain.senior.domain.entity.Profile;
 import com.postgraduate.domain.senior.domain.entity.Senior;
@@ -61,12 +62,29 @@ public class SeniorMapper {
                 .build();
     }
 
-    public static SeniorInfoResponse mapToSeniorInfo(Senior senior, Status certificationRegister, boolean profileRegister) {
-        return SeniorInfoResponse.builder()
+    public static SeniorMyPageResponse mapToSeniorMyPageInfo(Senior senior, Status certificationRegister, boolean profileRegister) {
+        return SeniorMyPageResponse.builder()
                 .nickName(senior.getUser().getNickName())
                 .profile(senior.getUser().getProfile())
                 .certificationRegister(certificationRegister)
                 .profileRegister(profileRegister)
+                .build();
+    }
+
+    public static SeniorInfoResponse mapToOriginInfo(Senior senior) {
+        User user = senior.getUser();
+        Info info = senior.getInfo();
+        Profile profile = senior.getProfile();
+        return SeniorInfoResponse.builder()
+                .profile(user.getProfile())
+                .nickName(user.getNickName())
+                .lab(info.getLab())
+                .keyword(info.getKeyword())
+                .field(info.getField())
+                .info(profile.getInfo())
+                .target(profile.getTarget())
+                .chatLink(profile.getChatLink())
+                .oneLiner(profile.getOneLiner())
                 .build();
     }
 

--- a/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
@@ -1,9 +1,8 @@
 package com.postgraduate.domain.senior.application.mapper;
 
 import com.postgraduate.domain.auth.application.dto.req.SeniorChangeRequest;
-import com.postgraduate.domain.salary.domain.entity.Salary;
-import com.postgraduate.domain.senior.application.dto.req.SeniorProfileRequest;
 import com.postgraduate.domain.auth.application.dto.req.SeniorSignUpRequest;
+import com.postgraduate.domain.senior.application.dto.req.SeniorProfileRequest;
 import com.postgraduate.domain.senior.application.dto.res.SeniorInfoResponse;
 import com.postgraduate.domain.senior.domain.entity.Info;
 import com.postgraduate.domain.senior.domain.entity.Profile;
@@ -61,12 +60,10 @@ public class SeniorMapper {
                 .build();
     }
 
-    public static SeniorInfoResponse mapToSeniorInfo(Senior senior, Salary salary, String month, Status certificationRegister, boolean profileRegister) {
+    public static SeniorInfoResponse mapToSeniorInfo(Senior senior, Status certificationRegister, boolean profileRegister) {
         return SeniorInfoResponse.builder()
                 .nickName(senior.getUser().getNickName())
                 .profile(senior.getUser().getProfile())
-                .month(month)
-                .amount(salary.getAmount())
                 .certificationRegister(certificationRegister)
                 .profileRegister(profileRegister)
                 .build();

--- a/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
@@ -2,6 +2,7 @@ package com.postgraduate.domain.senior.application.mapper;
 
 import com.postgraduate.domain.auth.application.dto.req.SeniorChangeRequest;
 import com.postgraduate.domain.auth.application.dto.req.SeniorSignUpRequest;
+import com.postgraduate.domain.senior.application.dto.res.SeniorDetailResponse;
 import com.postgraduate.domain.senior.application.dto.req.SeniorProfileRequest;
 import com.postgraduate.domain.senior.application.dto.res.SeniorInfoResponse;
 import com.postgraduate.domain.senior.domain.entity.Info;
@@ -66,6 +67,23 @@ public class SeniorMapper {
                 .profile(senior.getUser().getProfile())
                 .certificationRegister(certificationRegister)
                 .profileRegister(profileRegister)
+                .build();
+    }
+
+    public static SeniorDetailResponse mapToSeniorDetail(Senior senior) {
+        String[] keyword = senior.getInfo().getKeyword().split(",");
+        return SeniorDetailResponse.builder()
+                .nickName(senior.getUser().getNickName())
+                .profile(senior.getUser().getProfile())
+                .postgradu(senior.getInfo().getPostgradu())
+                .major(senior.getInfo().getMajor())
+                .lab(senior.getInfo().getLab())
+                .professor(senior.getInfo().getProfessor())
+                .keyword(keyword)
+                .info(senior.getProfile().getInfo())
+                .oneLiner(senior.getProfile().getOneLiner())
+                .target(senior.getProfile().getTarget())
+                .time(senior.getProfile().getTime())
                 .build();
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
@@ -3,6 +3,7 @@ package com.postgraduate.domain.senior.application.usecase;
 import com.postgraduate.domain.senior.application.dto.res.SeniorDetailResponse;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
+import com.postgraduate.domain.senior.domain.service.SeniorUpdateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,9 +13,11 @@ import static com.postgraduate.domain.senior.application.mapper.SeniorMapper.map
 @RequiredArgsConstructor
 public class SeniorInfoUseCase {
     private final SeniorGetService seniorGetService;
+    private final SeniorUpdateService seniorUpdateService;
 
     public SeniorDetailResponse getSeniorDetail(Long seniorId) {
         Senior senior = seniorGetService.bySeniorIdWithCertification(seniorId);
+        seniorUpdateService.updateHit(senior);
         return mapToSeniorDetail(senior);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
@@ -1,0 +1,20 @@
+package com.postgraduate.domain.senior.application.usecase;
+
+import com.postgraduate.domain.senior.application.dto.res.SeniorDetailResponse;
+import com.postgraduate.domain.senior.domain.entity.Senior;
+import com.postgraduate.domain.senior.domain.service.SeniorGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.postgraduate.domain.senior.application.mapper.SeniorMapper.mapToSeniorDetail;
+
+@Service
+@RequiredArgsConstructor
+public class SeniorInfoUseCase {
+    private final SeniorGetService seniorGetService;
+
+    public SeniorDetailResponse getSeniorDetail(Long seniorId) {
+        Senior senior = seniorGetService.bySeniorIdWithCertification(seniorId);
+        return mapToSeniorDetail(senior);
+    }
+}

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
@@ -1,12 +1,12 @@
 package com.postgraduate.domain.senior.application.usecase;
 
-import com.postgraduate.domain.account.application.mapper.AccountMapper;
 import com.postgraduate.domain.account.domain.entity.Account;
 import com.postgraduate.domain.account.domain.service.AccountGetService;
 import com.postgraduate.domain.account.domain.service.AccountSaveService;
 import com.postgraduate.domain.account.domain.service.AccountUpdateService;
 import com.postgraduate.domain.senior.application.dto.req.SeniorAccountRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorCertificationRequest;
+import com.postgraduate.domain.senior.application.dto.req.SeniorMyPageProfileRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorProfileRequest;
 import com.postgraduate.domain.senior.application.mapper.SeniorMapper;
 import com.postgraduate.domain.senior.domain.entity.Profile;
@@ -14,6 +14,8 @@ import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
 import com.postgraduate.domain.senior.domain.service.SeniorUpdateService;
 import com.postgraduate.domain.user.domain.entity.User;
+import com.postgraduate.domain.user.domain.service.UserUpdateService;
+import com.postgraduate.global.config.security.util.EncryptorUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,11 +26,13 @@ import static com.postgraduate.domain.account.application.mapper.AccountMapper.m
 @Service
 @RequiredArgsConstructor
 public class SeniorManageUseCase {
+    private final UserUpdateService userUpdateService;
     private final SeniorUpdateService seniorUpdateService;
     private final SeniorGetService seniorGetService;
     private final AccountGetService accountGetService;
     private final AccountSaveService accountSaveService;
     private final AccountUpdateService accountUpdateService;
+    private final EncryptorUtils encryptorUtils;
 
     public void updateCertification(User user, SeniorCertificationRequest certificationRequest) {
         Senior senior = seniorGetService.byUser(user);
@@ -45,9 +49,17 @@ public class SeniorManageUseCase {
         Senior senior = seniorGetService.byUser(user);
         Optional<Account> account = accountGetService.bySenior(senior);
         if (account.isEmpty()) {
-            accountSaveService.saveAccount(mapToAccount(senior, accountRequest));
+            String accountNumber = encryptorUtils.encryptData(accountRequest.getAccountNumber());
+            String rrn = encryptorUtils.encryptData(accountRequest.getRrn());
+            accountSaveService.saveAccount(mapToAccount(senior, accountRequest, accountNumber, rrn));
             return;
         }
         accountUpdateService.updateAccount(account.get(), accountRequest);
+    }
+
+    public void updateSeniorMyPageProfile(User user, SeniorMyPageProfileRequest myPageProfileRequest) {
+        userUpdateService.updateSeniorMyPage(user.getUserId(), myPageProfileRequest);
+        Senior senior = seniorGetService.byUser(user);
+        seniorUpdateService.updateMyPageProfile(senior, myPageProfileRequest);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
@@ -53,7 +53,7 @@ public class SeniorMyPageUseCase {
         LocalDate settlementDate = getSettlementDate();
         List<Salary> salaries = salaryGetService.bySeniorAndSalaryDate(senior, settlementDate);
         int pay = getAmount(salaries);
-        return new SalaryInfoResponse(settlementDate, pay);
+        return new SalaryInfoResponse(settlementDate, pay); //TODO 수수료
     }
 
     private LocalDate getSettlementDate() {

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
@@ -23,7 +23,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static com.postgraduate.domain.salary.util.MonthFormat.getMonthFormat;
 import static java.util.Optional.ofNullable;
 
 @Service
@@ -38,12 +37,9 @@ public class SeniorMyPageUseCase {
 
     public SeniorInfoResponse seniorInfo(User user) {
         Senior senior = seniorGetService.byUser(user);
-        String month = LocalDate.now().format(getMonthFormat());
-        Salary salary = salaryGetService.bySeniorAndMonth(senior, month)
-                .orElse(new Salary());
         Status status = senior.getStatus();
         Optional<Profile> profile = ofNullable(senior.getProfile());
-        return SeniorMapper.mapToSeniorInfo(senior, salary, month, status, profile.isPresent());
+        return SeniorMapper.mapToSeniorInfo(senior, status, profile.isPresent());
     }
 
     public void updateSeniorMyPageProfile(User user, SeniorMyPageProfileRequest myPageProfileRequest) {

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
@@ -1,21 +1,20 @@
 package com.postgraduate.domain.senior.application.usecase;
 
-import com.postgraduate.domain.senior.application.dto.req.SeniorMyPageProfileRequest;
 import com.postgraduate.domain.senior.application.dto.res.SeniorInfoResponse;
-import com.postgraduate.domain.senior.application.mapper.SeniorMapper;
+import com.postgraduate.domain.senior.application.dto.res.SeniorMyPageResponse;
 import com.postgraduate.domain.senior.domain.entity.Profile;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.entity.constant.Status;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
-import com.postgraduate.domain.senior.domain.service.SeniorUpdateService;
 import com.postgraduate.domain.user.domain.entity.User;
-import com.postgraduate.domain.user.domain.service.UserUpdateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+import static com.postgraduate.domain.senior.application.mapper.SeniorMapper.mapToOriginInfo;
+import static com.postgraduate.domain.senior.application.mapper.SeniorMapper.mapToSeniorMyPageInfo;
 import static java.util.Optional.ofNullable;
 
 @Service
@@ -23,19 +22,16 @@ import static java.util.Optional.ofNullable;
 @Transactional
 public class SeniorMyPageUseCase {
     private final SeniorGetService seniorGetService;
-    private final SeniorUpdateService seniorUpdateService;
-    private final UserUpdateService userUpdateService;
 
-    public SeniorInfoResponse seniorInfo(User user) {
+    public SeniorMyPageResponse getSeniorInfo(User user) {
         Senior senior = seniorGetService.byUser(user);
         Status status = senior.getStatus();
         Optional<Profile> profile = ofNullable(senior.getProfile());
-        return SeniorMapper.mapToSeniorInfo(senior, status, profile.isPresent());
+        return mapToSeniorMyPageInfo(senior, status, profile.isPresent());
     }
 
-    public void updateSeniorMyPageProfile(User user, SeniorMyPageProfileRequest myPageProfileRequest) {
-        userUpdateService.updateSeniorMyPage(user.getUserId(), myPageProfileRequest);
+    public SeniorInfoResponse getSeniorOriginInfo(User user) {
         Senior senior = seniorGetService.byUser(user);
-        seniorUpdateService.updateMyPageProfile(senior, myPageProfileRequest);
+        return mapToOriginInfo(senior);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
@@ -1,6 +1,8 @@
 package com.postgraduate.domain.senior.application.usecase;
 
+import com.postgraduate.domain.salary.application.dto.res.SalaryDetailResponse;
 import com.postgraduate.domain.salary.application.dto.res.SalaryInfoResponse;
+import com.postgraduate.domain.salary.application.mapper.SalaryMapper;
 import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.salary.domain.service.SalaryGetService;
 import com.postgraduate.domain.senior.application.dto.req.SeniorMyPageProfileRequest;
@@ -70,5 +72,11 @@ public class SeniorMyPageUseCase {
                 .map(salary -> salary.getMentoring().getPay())
                 .mapToInt(Integer::intValue)
                 .sum();
+    }
+
+    public List<SalaryDetailResponse> getSalaryDetail(User user, Boolean status) {
+        Senior senior = seniorGetService.byUser(user);
+        List<Salary> salaries = salaryGetService.bySeniorAndStatus(senior, status);
+        return salaries.stream().map(SalaryMapper::mapToSalaryDetail).toList();
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
@@ -1,5 +1,6 @@
 package com.postgraduate.domain.senior.application.usecase;
 
+import com.postgraduate.domain.salary.application.dto.res.SalaryInfoResponse;
 import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.salary.domain.service.SalaryGetService;
 import com.postgraduate.domain.senior.application.dto.req.SeniorMyPageProfileRequest;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import static com.postgraduate.domain.salary.util.MonthFormat.getMonthFormat;
@@ -26,6 +28,7 @@ import static java.util.Optional.ofNullable;
 @RequiredArgsConstructor
 @Transactional
 public class SeniorMyPageUseCase {
+    private static final int SALARY_DATE = 10;
     private final SeniorGetService seniorGetService;
     private final SalaryGetService salaryGetService;
     private final SeniorUpdateService seniorUpdateService;
@@ -45,5 +48,27 @@ public class SeniorMyPageUseCase {
         userUpdateService.updateSeniorMyPage(user.getUserId(), myPageProfileRequest);
         Senior senior = seniorGetService.byUser(user);
         seniorUpdateService.updateMyPageProfile(senior, myPageProfileRequest);
+    }
+
+    public SalaryInfoResponse getSalary(User user) {
+        Senior senior = seniorGetService.byUser(user);
+        LocalDate settlementDate = getSettlementDate();
+        List<Salary> salaries = salaryGetService.bySeniorAndSalaryDate(senior, settlementDate);
+        int pay = getAmount(salaries);
+        return new SalaryInfoResponse(settlementDate, pay);
+    }
+
+    private LocalDate getSettlementDate() {
+        LocalDate now = LocalDate.now();
+        return now.getDayOfMonth() <= SALARY_DATE
+                ? now.withDayOfMonth(SALARY_DATE)
+                : now.plusMonths(1).withDayOfMonth(SALARY_DATE);
+    }
+
+    private int getAmount(List<Salary> salaries) {
+        return salaries.stream()
+                .map(salary -> salary.getMentoring().getPay())
+                .mapToInt(Integer::intValue)
+                .sum();
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
@@ -1,10 +1,5 @@
 package com.postgraduate.domain.senior.application.usecase;
 
-import com.postgraduate.domain.salary.application.dto.res.SalaryDetailResponse;
-import com.postgraduate.domain.salary.application.dto.res.SalaryInfoResponse;
-import com.postgraduate.domain.salary.application.mapper.SalaryMapper;
-import com.postgraduate.domain.salary.domain.entity.Salary;
-import com.postgraduate.domain.salary.domain.service.SalaryGetService;
 import com.postgraduate.domain.senior.application.dto.req.SeniorMyPageProfileRequest;
 import com.postgraduate.domain.senior.application.dto.res.SeniorInfoResponse;
 import com.postgraduate.domain.senior.application.mapper.SeniorMapper;
@@ -19,8 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
@@ -29,9 +22,7 @@ import static java.util.Optional.ofNullable;
 @RequiredArgsConstructor
 @Transactional
 public class SeniorMyPageUseCase {
-    private static final int SALARY_DATE = 10;
     private final SeniorGetService seniorGetService;
-    private final SalaryGetService salaryGetService;
     private final SeniorUpdateService seniorUpdateService;
     private final UserUpdateService userUpdateService;
 
@@ -46,33 +37,5 @@ public class SeniorMyPageUseCase {
         userUpdateService.updateSeniorMyPage(user.getUserId(), myPageProfileRequest);
         Senior senior = seniorGetService.byUser(user);
         seniorUpdateService.updateMyPageProfile(senior, myPageProfileRequest);
-    }
-
-    public SalaryInfoResponse getSalary(User user) {
-        Senior senior = seniorGetService.byUser(user);
-        LocalDate settlementDate = getSettlementDate();
-        List<Salary> salaries = salaryGetService.bySeniorAndSalaryDate(senior, settlementDate);
-        int pay = getAmount(salaries);
-        return new SalaryInfoResponse(settlementDate, pay); //TODO 수수료
-    }
-
-    private LocalDate getSettlementDate() {
-        LocalDate now = LocalDate.now();
-        return now.getDayOfMonth() <= SALARY_DATE
-                ? now.withDayOfMonth(SALARY_DATE)
-                : now.plusMonths(1).withDayOfMonth(SALARY_DATE);
-    }
-
-    private int getAmount(List<Salary> salaries) {
-        return salaries.stream()
-                .map(salary -> salary.getMentoring().getPay())
-                .mapToInt(Integer::intValue)
-                .sum();
-    }
-
-    public List<SalaryDetailResponse> getSalaryDetail(User user, Boolean status) {
-        Senior senior = seniorGetService.byUser(user);
-        List<Salary> salaries = salaryGetService.bySeniorAndStatus(senior, status);
-        return salaries.stream().map(SalaryMapper::mapToSalaryDetail).toList();
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/domain/entity/Senior.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/entity/Senior.java
@@ -71,4 +71,8 @@ public class Senior {
     public void updateStatus(Status status) {
         this.status = status;
     }
+
+    public void updateHit() {
+        this.hit++;
+    }
 }

--- a/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorRepository.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorRepository.java
@@ -11,5 +11,5 @@ import java.util.Optional;
 public interface SeniorRepository extends JpaRepository<Senior, Long> {
     Optional<Senior> findByUser(User user);
     Optional<Senior> findBySeniorIdAndProfileNotNullAndStatus(Long seniorId, Status status);
-    Optional<List<Senior>> findAllByStatus(Status status);
+    List<Senior> findAllByStatus(Status status);
 }

--- a/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorRepository.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorRepository.java
@@ -10,5 +10,6 @@ import java.util.Optional;
 
 public interface SeniorRepository extends JpaRepository<Senior, Long> {
     Optional<Senior> findByUser(User user);
+    Optional<Senior> findBySeniorIdAndProfileNotNullAndStatus(Long seniorId, Status status);
     Optional<List<Senior>> findAllByStatus(Status status);
 }

--- a/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorGetService.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorGetService.java
@@ -8,7 +8,6 @@ import com.postgraduate.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.postgraduate.domain.senior.domain.entity.constant.Status.APPROVE;
@@ -31,6 +30,6 @@ public class SeniorGetService {
     }
 
     public List<Senior> byStatus(Status status) {
-        return seniorRepository.findAllByStatus(status).orElse(new ArrayList<>());
+        return seniorRepository.findAllByStatus(status);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorGetService.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorGetService.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.postgraduate.domain.senior.domain.entity.constant.Status.APPROVE;
+
 @Service
 @RequiredArgsConstructor
 public class SeniorGetService {
@@ -22,6 +24,10 @@ public class SeniorGetService {
 
     public Senior bySeniorId(Long seniorId) {
         return seniorRepository.findById(seniorId).orElseThrow(NoneSeniorException::new);
+    }
+
+    public Senior bySeniorIdWithCertification(Long seniorId) {
+        return seniorRepository.findBySeniorIdAndProfileNotNullAndStatus(seniorId, APPROVE).orElseThrow(NoneSeniorException::new);
     }
 
     public List<Senior> byStatus(Status status) {

--- a/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorUpdateService.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorUpdateService.java
@@ -21,4 +21,8 @@ public class SeniorUpdateService {
     public void updateMyPageProfile(Senior senior, SeniorMyPageProfileRequest myPageProfileRequest) {
         senior.updateMyPage(myPageProfileRequest);
     }
+
+    public void updateHit(Senior senior) {
+        senior.updateHit();
+    }
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -4,8 +4,10 @@ import com.postgraduate.domain.senior.application.dto.req.SeniorAccountRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorCertificationRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorMyPageProfileRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorProfileRequest;
+import com.postgraduate.domain.senior.application.dto.res.SeniorDetailResponse;
 import com.postgraduate.domain.senior.application.dto.res.SeniorInfoResponse;
 import com.postgraduate.domain.senior.application.dto.res.SeniorMyPageResponse;
+import com.postgraduate.domain.senior.application.usecase.SeniorInfoUseCase;
 import com.postgraduate.domain.senior.application.usecase.SeniorManageUseCase;
 import com.postgraduate.domain.senior.application.usecase.SeniorMyPageUseCase;
 import com.postgraduate.domain.user.domain.entity.User;
@@ -27,6 +29,7 @@ import static com.postgraduate.domain.senior.presentation.constant.SeniorRespons
 public class SeniorController {
     private final SeniorMyPageUseCase seniorMyPageUseCase;
     private final SeniorManageUseCase seniorManageUseCase;
+    private final SeniorInfoUseCase seniorInfoUseCase;
 
     @PatchMapping("/certification")
     @Operation(summary = "대학원생 인증", description = "이미지 업로드 이후 url 담아서 요청")
@@ -72,5 +75,12 @@ public class SeniorController {
                                         @RequestBody SeniorMyPageProfileRequest myPageProfileRequest) {
         seniorManageUseCase.updateSeniorMyPageProfile(user, myPageProfileRequest);
         return ResponseDto.create(SENIOR_UPDATE.getCode(), UPDATE_MYPAGE_PROFILE.getMessage());
+    }
+
+    @GetMapping("/{seniorId}")
+    @Operation(summary = "대학원생 상세 조회")
+    public ResponseDto<SeniorDetailResponse> getSeniorDetails(@PathVariable Long seniorId) {
+        SeniorDetailResponse seniorDetail = seniorInfoUseCase.getSeniorDetail(seniorId);
+        return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_INFO.getMessage(), seniorDetail);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -6,7 +6,9 @@ import com.postgraduate.domain.senior.application.dto.req.SeniorAccountRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorCertificationRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorMyPageProfileRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorProfileRequest;
+import com.postgraduate.domain.senior.application.dto.res.SeniorDetailResponse;
 import com.postgraduate.domain.senior.application.dto.res.SeniorInfoResponse;
+import com.postgraduate.domain.senior.application.usecase.SeniorInfoUseCase;
 import com.postgraduate.domain.senior.application.usecase.SeniorManageUseCase;
 import com.postgraduate.domain.senior.application.usecase.SeniorMyPageUseCase;
 import com.postgraduate.domain.user.domain.entity.User;
@@ -34,6 +36,7 @@ import static com.postgraduate.domain.senior.presentation.constant.SeniorRespons
 public class SeniorController {
     private final SeniorMyPageUseCase seniorMyPageUseCase;
     private final SeniorManageUseCase seniorManageUseCase;
+    private final SeniorInfoUseCase seniorInfoUseCase;
 
     @PatchMapping("/certification")
     @Operation(summary = "대학원생 인증", description = "이미지 업로드 이후 url 담아서 요청")
@@ -72,6 +75,13 @@ public class SeniorController {
                                         @RequestBody SeniorMyPageProfileRequest myPageProfileRequest) {
         seniorMyPageUseCase.updateSeniorMyPageProfile(user, myPageProfileRequest);
         return ResponseDto.create(SENIOR_UPDATE.getCode(), UPDATE_MYPAGE_PROFILE.getMessage());
+    }
+
+    @GetMapping("/{seniorId}")
+    @Operation(summary = "대학원생 상세 조회")
+    public ResponseDto<SeniorDetailResponse> getSeniorDetails(@PathVariable Long seniorId) {
+        SeniorDetailResponse seniorDetail = seniorInfoUseCase.getSeniorDetail(seniorId);
+        return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_INFO.getMessage(), seniorDetail);
     }
 
     @GetMapping("/salary")

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -4,9 +4,8 @@ import com.postgraduate.domain.senior.application.dto.req.SeniorAccountRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorCertificationRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorMyPageProfileRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorProfileRequest;
-import com.postgraduate.domain.senior.application.dto.res.SeniorDetailResponse;
 import com.postgraduate.domain.senior.application.dto.res.SeniorInfoResponse;
-import com.postgraduate.domain.senior.application.usecase.SeniorInfoUseCase;
+import com.postgraduate.domain.senior.application.dto.res.SeniorMyPageResponse;
 import com.postgraduate.domain.senior.application.usecase.SeniorManageUseCase;
 import com.postgraduate.domain.senior.application.usecase.SeniorMyPageUseCase;
 import com.postgraduate.domain.user.domain.entity.User;
@@ -17,8 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode.SENIOR_FIND;
-import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode.SENIOR_UPDATE;
+import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode.*;
 import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseMessage.*;
 
 
@@ -29,7 +27,6 @@ import static com.postgraduate.domain.senior.presentation.constant.SeniorRespons
 public class SeniorController {
     private final SeniorMyPageUseCase seniorMyPageUseCase;
     private final SeniorManageUseCase seniorManageUseCase;
-    private final SeniorInfoUseCase seniorInfoUseCase;
 
     @PatchMapping("/certification")
     @Operation(summary = "대학원생 인증", description = "이미지 업로드 이후 url 담아서 요청")
@@ -57,23 +54,23 @@ public class SeniorController {
 
     @GetMapping("/me")
     @Operation(summary = "대학원생 마이페이지 기본 정보 조회", description = "닉네임, 프로필 사진, 인증 여부")
-    public ResponseDto<SeniorInfoResponse> getSeniorInfo(@AuthenticationPrincipal User user) {
-        SeniorInfoResponse seniorInfoResponse = seniorMyPageUseCase.seniorInfo(user);
-        return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_INFO.getMessage(), seniorInfoResponse);
+    public ResponseDto<SeniorMyPageResponse> getSeniorInfo(@AuthenticationPrincipal User user) {
+        SeniorMyPageResponse seniorMyPageResponse = seniorMyPageUseCase.getSeniorInfo(user);
+        return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_INFO.getMessage(), seniorMyPageResponse);
+    }
+
+    @GetMapping("/me/profile")
+    @Operation(summary = "대학생 마이페이지 프로필 수정시 기존 정보 조회")
+    public ResponseDto<SeniorInfoResponse> getSeniorProfile(@AuthenticationPrincipal User user) {
+        SeniorInfoResponse seniorOriginInfo = seniorMyPageUseCase.getSeniorOriginInfo(user);
+        return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_INFO.getMessage(), seniorOriginInfo);
     }
 
     @PatchMapping("/me/profile")
     @Operation(summary = "대학원생 마이페이지 프로필 수정")
-    public ResponseDto getSeniorProfile(@AuthenticationPrincipal User user,
+    public ResponseDto updateSeniorProfile(@AuthenticationPrincipal User user,
                                         @RequestBody SeniorMyPageProfileRequest myPageProfileRequest) {
-        seniorMyPageUseCase.updateSeniorMyPageProfile(user, myPageProfileRequest);
+        seniorManageUseCase.updateSeniorMyPageProfile(user, myPageProfileRequest);
         return ResponseDto.create(SENIOR_UPDATE.getCode(), UPDATE_MYPAGE_PROFILE.getMessage());
-    }
-
-    @GetMapping("/{seniorId}")
-    @Operation(summary = "대학원생 상세 조회")
-    public ResponseDto<SeniorDetailResponse> getSeniorDetails(@PathVariable Long seniorId) {
-        SeniorDetailResponse seniorDetail = seniorInfoUseCase.getSeniorDetail(seniorId);
-        return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_INFO.getMessage(), seniorDetail);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -1,7 +1,5 @@
 package com.postgraduate.domain.senior.presentation;
 
-import com.postgraduate.domain.salary.application.dto.res.SalaryDetailResponse;
-import com.postgraduate.domain.salary.application.dto.res.SalaryInfoResponse;
 import com.postgraduate.domain.senior.application.dto.req.SeniorAccountRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorCertificationRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorMyPageProfileRequest;
@@ -19,11 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
-import static com.postgraduate.domain.salary.presentation.constant.SalaryResponseCode.SALARY_FIND;
-import static com.postgraduate.domain.salary.presentation.constant.SalaryResponseMessage.GET_SALARY_INFO;
-import static com.postgraduate.domain.salary.presentation.constant.SalaryResponseMessage.GET_SALARY_LIST_INFO;
 import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode.SENIOR_FIND;
 import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode.SENIOR_UPDATE;
 import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseMessage.*;
@@ -82,26 +75,5 @@ public class SeniorController {
     public ResponseDto<SeniorDetailResponse> getSeniorDetails(@PathVariable Long seniorId) {
         SeniorDetailResponse seniorDetail = seniorInfoUseCase.getSeniorDetail(seniorId);
         return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_INFO.getMessage(), seniorDetail);
-    }
-
-    @GetMapping("/salary")
-    @Operation(summary = "대학원생 정산 예정액, 다음 정산 예정일 조회", description = "마이페이지에서 공통으로 보이는 정산 예정 정보입니다.")
-    public ResponseDto<SalaryInfoResponse> getSalary(@AuthenticationPrincipal User user) {
-        SalaryInfoResponse salary = seniorMyPageUseCase.getSalary(user);
-        return ResponseDto.create(SALARY_FIND.getCode(), GET_SALARY_INFO.getMessage(), salary);
-    }
-
-    @GetMapping("/salary/waiting")
-    @Operation(summary = "대학원생 정산예정 목록 조회", description = "정산 예정 탭에서 보이는 목록입니다.")
-    public ResponseDto<List<SalaryDetailResponse>> getWaitingSalary(@AuthenticationPrincipal User user) {
-        List<SalaryDetailResponse> salary = seniorMyPageUseCase.getSalaryDetail(user, false);
-        return ResponseDto.create(SALARY_FIND.getCode(), GET_SALARY_LIST_INFO.getMessage(), salary);
-    }
-
-    @GetMapping("/salary/done")
-    @Operation(summary = "대학원생 정산완료 목록 조회", description = "정산 완료 탭에서 보이는 목록입니다.")
-    public ResponseDto<List<SalaryDetailResponse>> getDoneSalary(@AuthenticationPrincipal User user) {
-        List<SalaryDetailResponse> salary = seniorMyPageUseCase.getSalaryDetail(user, true);
-        return ResponseDto.create(SALARY_FIND.getCode(), GET_SALARY_LIST_INFO.getMessage(), salary);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -1,5 +1,7 @@
 package com.postgraduate.domain.senior.presentation;
 
+import com.postgraduate.domain.salary.application.dto.res.SalaryDetailResponse;
+import com.postgraduate.domain.salary.application.dto.res.SalaryInfoResponse;
 import com.postgraduate.domain.senior.application.dto.req.SeniorAccountRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorCertificationRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorMyPageProfileRequest;
@@ -15,7 +17,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode.*;
+import java.util.List;
+
+import static com.postgraduate.domain.salary.presentation.constant.SalaryResponseCode.SALARY_FIND;
+import static com.postgraduate.domain.salary.presentation.constant.SalaryResponseMessage.GET_SALARY_INFO;
+import static com.postgraduate.domain.salary.presentation.constant.SalaryResponseMessage.GET_SALARY_LIST_INFO;
+import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode.SENIOR_FIND;
+import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode.SENIOR_UPDATE;
 import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseMessage.*;
 
 
@@ -71,5 +79,19 @@ public class SeniorController {
     public ResponseDto<SalaryInfoResponse> getSalary(@AuthenticationPrincipal User user) {
         SalaryInfoResponse salary = seniorMyPageUseCase.getSalary(user);
         return ResponseDto.create(SALARY_FIND.getCode(), GET_SALARY_INFO    .getMessage(), salary);
+    }
+
+    @GetMapping("/salary/waiting")
+    @Operation(summary = "대학원생 정산예정 목록 조회", description = "정산 예정 탭에서 보이는 목록입니다.")
+    public ResponseDto<List<SalaryDetailResponse>> getWaitingSalary(@AuthenticationPrincipal User user) {
+        List<SalaryDetailResponse> salary = seniorMyPageUseCase.getSalaryDetail(user, false);
+        return ResponseDto.create(SALARY_FIND.getCode(), GET_SALARY_LIST_INFO.getMessage(), salary);
+    }
+
+    @GetMapping("/salary/done")
+    @Operation(summary = "대학원생 정산완료 목록 조회", description = "정산 완료 탭에서 보이는 목록입니다.")
+    public ResponseDto<List<SalaryDetailResponse>> getDoneSalary(@AuthenticationPrincipal User user) {
+        List<SalaryDetailResponse> salary = seniorMyPageUseCase.getSalaryDetail(user, true);
+        return ResponseDto.create(SALARY_FIND.getCode(), GET_SALARY_LIST_INFO.getMessage(), salary);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -78,7 +78,7 @@ public class SeniorController {
     @Operation(summary = "대학원생 정산 예정액, 다음 정산 예정일 조회", description = "마이페이지에서 공통으로 보이는 정산 예정 정보입니다.")
     public ResponseDto<SalaryInfoResponse> getSalary(@AuthenticationPrincipal User user) {
         SalaryInfoResponse salary = seniorMyPageUseCase.getSalary(user);
-        return ResponseDto.create(SALARY_FIND.getCode(), GET_SALARY_INFO    .getMessage(), salary);
+        return ResponseDto.create(SALARY_FIND.getCode(), GET_SALARY_INFO.getMessage(), salary);
     }
 
     @GetMapping("/salary/waiting")

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -65,4 +65,11 @@ public class SeniorController {
         seniorMyPageUseCase.updateSeniorMyPageProfile(user, myPageProfileRequest);
         return ResponseDto.create(SENIOR_UPDATE.getCode(), UPDATE_MYPAGE_PROFILE.getMessage());
     }
+
+    @GetMapping("/salary")
+    @Operation(summary = "대학원생 정산 예정액, 다음 정산 예정일 조회", description = "마이페이지에서 공통으로 보이는 정산 예정 정보입니다.")
+    public ResponseDto<SalaryInfoResponse> getSalary(@AuthenticationPrincipal User user) {
+        SalaryInfoResponse salary = seniorMyPageUseCase.getSalary(user);
+        return ResponseDto.create(SALARY_FIND.getCode(), GET_SALARY_INFO    .getMessage(), salary);
+    }
 }

--- a/src/main/java/com/postgraduate/domain/user/application/dto/req/UserInfoRequest.java
+++ b/src/main/java/com/postgraduate/domain/user/application/dto/req/UserInfoRequest.java
@@ -1,0 +1,18 @@
+package com.postgraduate.domain.user.application.dto.req;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserInfoRequest {
+    @NotNull
+    private String profile;
+    @NotNull
+    private String nickName;
+    @NotNull
+    private String phoneNumber;
+}

--- a/src/main/java/com/postgraduate/domain/user/application/dto/res/UserMyPageResponse.java
+++ b/src/main/java/com/postgraduate/domain/user/application/dto/res/UserMyPageResponse.java
@@ -7,8 +7,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-public class UserInfoResponse {
-    private String profile;
+public class UserMyPageResponse {
     private String nickName;
-    private String phoneNumber;
+    private String profile;
 }

--- a/src/main/java/com/postgraduate/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/postgraduate/domain/user/application/mapper/UserMapper.java
@@ -3,16 +3,24 @@ package com.postgraduate.domain.user.application.mapper;
 import com.postgraduate.domain.auth.application.dto.req.SeniorSignUpRequest;
 import com.postgraduate.domain.auth.application.dto.req.SignUpRequest;
 import com.postgraduate.domain.user.application.dto.res.UserInfoResponse;
+import com.postgraduate.domain.user.application.dto.res.UserMyPageResponse;
 import com.postgraduate.domain.user.domain.entity.User;
-import com.postgraduate.domain.user.domain.entity.constant.Role;
 
 import static com.postgraduate.domain.user.domain.entity.constant.Role.SENIOR;
 
 public class UserMapper {
-    public static UserInfoResponse mapToInfo(User user) {
-        return UserInfoResponse.builder()
+    public static UserMyPageResponse mapToMyPageInfo(User user) {
+        return UserMyPageResponse.builder()
                 .nickName(user.getNickName())
                 .profile(user.getProfile())
+                .build();
+    }
+
+    public static UserInfoResponse mapToInfo(User user) {
+        return UserInfoResponse.builder()
+                .profile(user.getProfile())
+                .nickName(user.getNickName())
+                .phoneNumber(user.getPhoneNumber())
                 .build();
     }
 

--- a/src/main/java/com/postgraduate/domain/user/application/usecase/UserManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/user/application/usecase/UserManageUseCase.java
@@ -1,16 +1,12 @@
 package com.postgraduate.domain.user.application.usecase;
 
 import com.postgraduate.domain.user.application.dto.req.UserInfoRequest;
-import com.postgraduate.domain.user.application.dto.res.UserInfoResponse;
-import com.postgraduate.domain.user.application.mapper.UserMapper;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.service.UserGetService;
 import com.postgraduate.domain.user.domain.service.UserUpdateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.postgraduate.domain.user.application.mapper.UserMapper.mapToInfo;
 
 @Transactional
 @Service

--- a/src/main/java/com/postgraduate/domain/user/application/usecase/UserManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/user/application/usecase/UserManageUseCase.java
@@ -1,11 +1,16 @@
 package com.postgraduate.domain.user.application.usecase;
 
+import com.postgraduate.domain.user.application.dto.req.UserInfoRequest;
+import com.postgraduate.domain.user.application.dto.res.UserInfoResponse;
+import com.postgraduate.domain.user.application.mapper.UserMapper;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.service.UserGetService;
 import com.postgraduate.domain.user.domain.service.UserUpdateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.postgraduate.domain.user.application.mapper.UserMapper.mapToInfo;
 
 @Transactional
 @Service
@@ -14,12 +19,8 @@ public class UserManageUseCase {
     private final UserUpdateService userUpdateService;
     private final UserGetService userGetService;
 
-    public void updateNickName(User user, String nickName) {
-        userUpdateService.updateNickName(user.getUserId(), nickName);
-    }
-
-    public void updateProfile(User user, String profile) {
-        userUpdateService.updateProfile(user.getUserId(), profile);
+    public void updateInfo(User user, UserInfoRequest userInfoRequest) {
+        userUpdateService.updateInfo(user.getUserId(), userInfoRequest);
     }
 
     public boolean duplicatedNickName(String nickName) {

--- a/src/main/java/com/postgraduate/domain/user/application/usecase/UserMyPageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/user/application/usecase/UserMyPageUseCase.java
@@ -1,19 +1,33 @@
 package com.postgraduate.domain.user.application.usecase;
 
 import com.postgraduate.domain.user.application.dto.res.UserInfoResponse;
+import com.postgraduate.domain.user.application.dto.res.UserMyPageResponse;
 import com.postgraduate.domain.user.application.mapper.UserMapper;
 import com.postgraduate.domain.user.domain.entity.User;
-import com.postgraduate.domain.user.domain.service.UserGetService;
-import com.postgraduate.domain.user.domain.service.UserUpdateService;
+import com.postgraduate.domain.user.domain.entity.constant.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.postgraduate.domain.user.application.mapper.UserMapper.mapToInfo;
+import static com.postgraduate.domain.user.domain.entity.constant.Role.SENIOR;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class UserMyPageUseCase {
-    public UserInfoResponse getUserInfo(User user) {
-        return UserMapper.mapToInfo(user);
+    public UserMyPageResponse getUserInfo(User user) {
+        return UserMapper.mapToMyPageInfo(user);
+    }
+
+    public UserInfoResponse getUserOriginInfo(User user) {
+        return mapToInfo(user);
+    }
+
+    public boolean checkSenior(User user) {
+        Role role = user.getRole();
+        if (role.equals(SENIOR))
+            return true;
+        return false;
     }
 }

--- a/src/main/java/com/postgraduate/domain/user/domain/entity/User.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/entity/User.java
@@ -66,6 +66,12 @@ public class User {
         this.profile = profile;
     }
 
+    public void updateInfo(String profile, String nickName, String phoneNumber) {
+        this.profile = profile;
+        this.nickName = nickName;
+        this.phoneNumber = phoneNumber;
+    }
+
     public void updateSeniorMyPage(SeniorMyPageProfileRequest request) {
         this.profile = request.getProfile();
         this.nickName = request.getNickName();

--- a/src/main/java/com/postgraduate/domain/user/domain/service/UserUpdateService.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/service/UserUpdateService.java
@@ -1,6 +1,7 @@
 package com.postgraduate.domain.user.domain.service;
 
 import com.postgraduate.domain.senior.application.dto.req.SeniorMyPageProfileRequest;
+import com.postgraduate.domain.user.application.dto.req.UserInfoRequest;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.entity.constant.Role;
 import com.postgraduate.domain.user.domain.repository.UserRepository;
@@ -12,19 +13,18 @@ import org.springframework.stereotype.Service;
 public class UserUpdateService {
     private final UserRepository userRepository;
 
-    public void updateNickName(Long userId, String nickName) {
-        User user = userRepository.findById(userId).get();
-        user.updateNickName(nickName);
-    }
-
     public void updateRole(Long userId, Role role) {
         User user = userRepository.findById(userId).get();
         user.updateRole(role);
     }
 
-    public void updateProfile(Long userId, String profile) {
+    public void updateInfo(Long userId, UserInfoRequest userInfoRequest) {
         User user = userRepository.findById(userId).get();
-        user.updateProfile(profile);
+        user.updateInfo(
+                userInfoRequest.getProfile(),
+                userInfoRequest.getNickName(),
+                userInfoRequest.getPhoneNumber()
+        );
     }
 
     public void updateSeniorMyPage(Long userId, SeniorMyPageProfileRequest myPageProfileRequest) {

--- a/src/main/java/com/postgraduate/domain/user/presentation/UserController.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/UserController.java
@@ -1,8 +1,8 @@
 package com.postgraduate.domain.user.presentation;
 
-import com.postgraduate.domain.user.application.dto.req.UserNickNameRequest;
-import com.postgraduate.domain.user.application.dto.req.UserProfileRequest;
+import com.postgraduate.domain.user.application.dto.req.UserInfoRequest;
 import com.postgraduate.domain.user.application.dto.res.UserInfoResponse;
+import com.postgraduate.domain.user.application.dto.res.UserMyPageResponse;
 import com.postgraduate.domain.user.application.usecase.UserManageUseCase;
 import com.postgraduate.domain.user.application.usecase.UserMyPageUseCase;
 import com.postgraduate.domain.user.domain.entity.User;
@@ -26,17 +26,31 @@ public class UserController {
     private final UserManageUseCase manageUseCase;
 
     @GetMapping("/me")
-    @Operation(description = "사용자 기본 정보 조회 - 닉네임, 프로필")
-    public ResponseDto<UserInfoResponse> getUserInfo(@AuthenticationPrincipal User user) {
-        UserInfoResponse userInfo = myPageUseCase.getUserInfo(user);
+    @Operation(description = "사용자 마이페이지 정보 조회 - 닉네임, 프로필")
+    public ResponseDto<UserMyPageResponse> getUserInfo(@AuthenticationPrincipal User user) {
+        UserMyPageResponse userInfo = myPageUseCase.getUserInfo(user);
         return ResponseDto.create(USER_FIND.getCode(), GET_USER_INFO.getMessage(), userInfo);
     }
 
-    @PatchMapping("/nickname")
-    @Operation(description = "사용자 닉네임 변경 및 업데이트")
-    public ResponseDto updateNickName(@AuthenticationPrincipal User user, @RequestBody UserNickNameRequest userNickNameRequest) {
-        manageUseCase.updateNickName(user, userNickNameRequest.getNickName());
+    @GetMapping("/me/info")
+    @Operation(description = "대학생 마이페이지 정보 수정시 기존 정보 조회")
+    public ResponseDto<UserInfoResponse> getOriginUserInfo(@AuthenticationPrincipal User user) {
+        UserInfoResponse originInfo = myPageUseCase.getUserOriginInfo(user);
+        return ResponseDto.create(USER_FIND.getCode(), GET_USER_INFO.getMessage(), originInfo);
+    }
+
+    @PatchMapping("/me/info")
+    @Operation(description = "대학생 마이페이지 정보 수정 - 프로필사진, 닉네임, 번호")
+    public ResponseDto updateInfo(@AuthenticationPrincipal User user, @RequestBody UserInfoRequest userInfoRequest) {
+        manageUseCase.updateInfo(user, userInfoRequest);
         return ResponseDto.create(USER_UPDATE.getCode(), UPDATE_USER_INFO.getMessage());
+    }
+
+    @GetMapping("/me/role")
+    @Operation(description = "선배 전환시 가능 여부 확인 - true,false")
+    public ResponseDto<Boolean> checkRole(@AuthenticationPrincipal User user) {
+        boolean isOk = myPageUseCase.checkSenior(user);
+        return ResponseDto.create(USER_FIND.getCode(), GET_SENIOR_CHECK.getMessage(), isOk);
     }
 
     @GetMapping("/nickname")
@@ -44,12 +58,5 @@ public class UserController {
     public ResponseDto<Boolean> duplicatedNickName(@RequestParam String nickName) {
         boolean checkDup = manageUseCase.duplicatedNickName(nickName);
         return ResponseDto.create(USER_FIND.getCode(), GET_NICKNAME_CHECK.getMessage(), checkDup);
-    }
-
-    @PatchMapping("/profile")
-    @Operation(description = "사용자 프로필 사진 업데이트 - url을 주세요")
-    public ResponseDto updateProfile(@AuthenticationPrincipal User user, @RequestBody UserProfileRequest userProfileRequest) {
-        manageUseCase.updateProfile(user, userProfileRequest.getProfile());
-        return ResponseDto.create(USER_UPDATE.getCode(), UPDATE_USER_INFO.getMessage());
     }
 }

--- a/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseMessage.java
@@ -9,6 +9,7 @@ public enum UserResponseMessage {
     GET_USER_INFO("사용자 기본 정보 조회에 성공하였습니다."),
     GET_USER_LIST_INFO("사용자 목록 조회에 성공하였습니다."),
     GET_NICKNAME_CHECK("닉네임 중복체크에 성공하였습니다."),
+    GET_SENIOR_CHECK("선배 변환 가능 여부 조회에 성공하였습니다."),
     UPDATE_USER_INFO("사용자 업데이트에 성공하였습니다."),
 
     NOT_FOUND_USER("등록된 사용자가 없습니다.");

--- a/src/main/java/com/postgraduate/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/postgraduate/global/config/security/SecurityConfig.java
@@ -13,17 +13,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.UUID;
-
-import static java.util.UUID.randomUUID;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/java/com/postgraduate/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/postgraduate/global/config/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.postgraduate.global.config.security.filter.CustomAuthenticationEntryP
 import com.postgraduate.global.config.security.jwt.JwtFilter;
 import com.postgraduate.global.config.security.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -13,11 +14,16 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.UUID;
+
+import static java.util.UUID.randomUUID;
 
 @Configuration
 @EnableWebSecurity
@@ -27,9 +33,14 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    @Value("${aesBytesEncryptor.secret}")
+    private String secretKey;
+    @Value("${aesBytesEncryptor.salt}")
+    private String salt;
+
     @Bean
-    public BCryptPasswordEncoder encodePassword() {
-        return new BCryptPasswordEncoder();
+    public AesBytesEncryptor aesBytesEncryptor() {
+        return new AesBytesEncryptor(secretKey, salt);
     }
 
     @Bean

--- a/src/main/java/com/postgraduate/global/config/security/filter/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/postgraduate/global/config/security/filter/CustomAccessDeniedHandler.java
@@ -1,0 +1,33 @@
+package com.postgraduate.global.config.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.postgraduate.global.dto.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.postgraduate.domain.auth.presentation.contant.AuthResponseCode.AUTH_DENIED;
+import static com.postgraduate.domain.auth.presentation.contant.AuthResponseMessage.PERMISSION_DENIED;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(
+                response.getOutputStream(),
+                new ErrorResponse(AUTH_DENIED.getCode(), PERMISSION_DENIED.getMessage())
+        );
+    }
+}

--- a/src/main/java/com/postgraduate/global/config/security/filter/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/postgraduate/global/config/security/filter/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package com.postgraduate.global.config.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.postgraduate.global.dto.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.postgraduate.domain.auth.presentation.contant.AuthResponseCode.AUTH_FAILED;
+import static com.postgraduate.domain.auth.presentation.contant.AuthResponseMessage.FAILED_AUTH;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(
+                response.getOutputStream(),
+                new ErrorResponse(AUTH_FAILED.getCode(), FAILED_AUTH.getMessage())
+        );
+    }
+}

--- a/src/main/java/com/postgraduate/global/config/security/util/EncryptorUtils.java
+++ b/src/main/java/com/postgraduate/global/config/security/util/EncryptorUtils.java
@@ -1,0 +1,44 @@
+package com.postgraduate.global.config.security.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
+import org.springframework.stereotype.Component;
+
+import java.nio.ByteBuffer;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@Component
+@RequiredArgsConstructor
+public class EncryptorUtils {
+    private final AesBytesEncryptor encryptor;
+
+    public String encryptData(String data) {
+        byte[] encrypt = encryptor.encrypt(data.getBytes(UTF_8));
+        return byteArrayToString(encrypt);
+    }
+
+    public String decryptData(String data) {
+        byte[] decryptBytes = stringToByteArray(data);
+        byte[] decrypt = encryptor.decrypt(decryptBytes);
+        return new String(decrypt, UTF_8);
+    }
+
+    public String byteArrayToString(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (byte abyte : bytes) {
+            sb.append(abyte);
+            sb.append(" ");
+        }
+        return sb.toString();
+    }
+
+    public byte[] stringToByteArray(String byteString) {
+        String[] split = byteString.split("\\s");
+        ByteBuffer buffer = ByteBuffer.allocate(split.length);
+        for (String s : split) {
+            buffer.put((byte) Integer.parseInt(s));
+        }
+        return buffer.array();
+    }
+}

--- a/src/test/java/com/postgraduate/domain/user/application/usecase/UserMyPageUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/user/application/usecase/UserMyPageUseCaseTest.java
@@ -1,22 +1,9 @@
 package com.postgraduate.domain.user.application.usecase;
 
-import com.postgraduate.domain.user.application.dto.res.UserInfoResponse;
-import com.postgraduate.domain.user.domain.entity.User;
-import com.postgraduate.domain.user.domain.entity.constant.Role;
-import com.postgraduate.domain.user.domain.service.UserGetService;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDate;
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 public class UserMyPageUseCaseTest {

--- a/src/test/java/com/postgraduate/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/postgraduate/domain/user/presentation/UserControllerTest.java
@@ -1,38 +1,9 @@
 package com.postgraduate.domain.user.presentation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.postgraduate.domain.user.application.dto.req.UserNickNameRequest;
-import com.postgraduate.domain.user.application.dto.req.UserProfileRequest;
-import com.postgraduate.domain.user.application.dto.res.UserInfoResponse;
-import com.postgraduate.domain.user.application.usecase.UserMyPageUseCase;
-import com.postgraduate.domain.user.domain.entity.User;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
-import java.time.LocalDate;
-
-import static com.postgraduate.domain.user.domain.entity.constant.Role.USER;
-import static com.postgraduate.domain.user.presentation.constant.UserResponseCode.USER_FIND;
-import static com.postgraduate.domain.user.presentation.constant.UserResponseCode.USER_UPDATE;
-import static com.postgraduate.domain.user.presentation.constant.UserResponseMessage.GET_NICKNAME_CHECK;
-import static com.postgraduate.domain.user.presentation.constant.UserResponseMessage.UPDATE_USER_INFO;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(UserController.class)
 class UserControllerTest {


### PR DESCRIPTION
## 🦝 PR 요약
+ 대학원생 정산 조회 기능을 구현했습니다.

## ✨ PR 상세 내용
+ 정산예정액, 정산예정일 API - 기존 대학원생 마이페이지 API와 분리
+ 정산예정 조회 API
+ 정산완료 조회 API
+ 멘토링 `DONE` → Salary 생성
  + salaryDate 은 now에서 가장 가까운 미래의 10일
  + ex) now(11/20) → salaryDate(12/10)
  + ex) now(11/1) → salaryDate(11/10)


## 🚨 주의 사항
+ salary 테이블이 변경되었습니다. 
  + mentoring 과 일대일
  + senior 과 다대일
  + salaryDate 는 매달 정산일 (현재는 매월 10일)
  + status 는 상태 (default false)

<img width="212" alt="image" src="https://github.com/WE-ARE-RACCOONS/postgraduate-back/assets/110026001/399d61da-510d-4d36-b66e-4a2f6e906eef">

+ 수수료 계산은 추후에 정해지면 추가하겠습니다.

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
