### PR TITLE
RAC-185 feat : 대학원생 분야 필터 추가

### DIFF
--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/AllSeniorFieldResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/AllSeniorFieldResponse.java
@@ -1,0 +1,7 @@
+package com.postgraduate.domain.senior.application.dto.res;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record AllSeniorFieldResponse(@NotNull List<SeniorFieldResponse> seniorFieldResponses) { }

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorFieldResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorFieldResponse.java
@@ -3,6 +3,7 @@ package com.postgraduate.domain.senior.application.dto.res;
 import jakarta.validation.constraints.NotNull;
 
 public record SeniorFieldResponse(
+        @NotNull Long seniorId,
         @NotNull String profile,
         @NotNull String nickName,
         @NotNull String postgradu,

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorFieldResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorFieldResponse.java
@@ -1,0 +1,11 @@
+package com.postgraduate.domain.senior.application.dto.res;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SeniorFieldResponse(
+        @NotNull String profile,
+        @NotNull String nickName,
+        @NotNull String postgradu,
+        @NotNull String major,
+        @NotNull String lab
+) {}

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorMyPageResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorMyPageResponse.java
@@ -1,16 +1,9 @@
 package com.postgraduate.domain.senior.application.dto.res;
 
 import com.postgraduate.domain.senior.domain.entity.constant.Status;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import jakarta.validation.constraints.NotNull;
 
-@Builder
-@Getter
-@AllArgsConstructor
-public class SeniorMyPageResponse {
-    private String nickName;
-    private String profile;
-    private Status certificationRegister;
-    private boolean profileRegister;
+public record SeniorMyPageResponse(@NotNull Long seniorId, @NotNull String nickName, @NotNull String profile,
+                                   @NotNull Status certificationRegister, @NotNull Boolean profileRegister) {
+
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorSearchResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorSearchResponse.java
@@ -4,6 +4,8 @@ import jakarta.validation.constraints.NotNull;
 
 public record SeniorSearchResponse(
         @NotNull
+        Long seniorId,
+        @NotNull
         String profile,
         @NotNull
         String nickName,

--- a/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
@@ -39,9 +39,9 @@ public class SeniorMapper {
                 .keyword(request.keyword())
                 .field(request.field())
                 .etcPostgradu(false)
-                .etcPostgradu(false)
+                .etcField(false)
                 .totalInfo(request.major() + request.lab() + request.field()
-                        + request.professor() + request.postgradu() + request.field());
+                        + request.professor() + request.postgradu() + request.keyword());
 
         for (String field : fields) {
             if (!fieldNames.contains(field)) {
@@ -99,9 +99,9 @@ public class SeniorMapper {
                 .keyword(request.keyword())
                 .field(request.field())
                 .etcPostgradu(false)
-                .etcPostgradu(false)
+                .etcField(false)
                 .totalInfo(request.major() + request.lab() + request.field()
-                        + request.professor() + request.postgradu() + request.field());
+                        + request.professor() + request.postgradu() + request.keyword());
 
         for (String field : fields) {
             if (!fieldNames.contains(field)) {

--- a/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
@@ -148,4 +148,11 @@ public class SeniorMapper {
                 info.getPostgradu(), info.getMajor(), info.getLab(),
                 profile.getOneLiner(), keyword);
     }
+
+    public static SeniorFieldResponse mapToSeniorField(Senior senior) {
+        User user = senior.getUser();
+        Info info = senior.getInfo();
+        return new SeniorFieldResponse(user.getProfile(), user.getNickName(),
+                info.getPostgradu(), info.getMajor(), info.getLab());
+    }
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
@@ -49,12 +49,9 @@ public class SeniorMapper {
                 break;
             }
         }
-        for (String postgradu : postgraduNames) {
-            if (!postgraduNames.contains(postgradu)) {
-                infoBuilder.etcPostgradu(true);
-                break;
-            }
-        }
+        if (!postgraduNames.contains(request.postgradu()))
+            infoBuilder.etcPostgradu(true);
+
         return infoBuilder.build();
     }
 
@@ -115,12 +112,8 @@ public class SeniorMapper {
     }
 
     public static SeniorMyPageResponse mapToSeniorMyPageInfo(Senior senior, Status certificationRegister, boolean profileRegister) {
-        return SeniorMyPageResponse.builder()
-                .nickName(senior.getUser().getNickName())
-                .profile(senior.getUser().getProfile())
-                .certificationRegister(certificationRegister)
-                .profileRegister(profileRegister)
-                .build();
+        User user = senior.getUser();
+        return new SeniorMyPageResponse(senior.getSeniorId(), user.getNickName(), user.getProfile(), certificationRegister, profileRegister);
     }
 
     public static SeniorMyPageProfileResponse mapToMyPageProfile(Senior senior) {
@@ -182,7 +175,7 @@ public class SeniorMapper {
         Profile profile = senior.getProfile();
         String[] keyword = info.getKeyword().split(",");
 
-        return new SeniorSearchResponse(user.getProfile(), user.getNickName(),
+        return new SeniorSearchResponse(senior.getSeniorId(), user.getProfile(), user.getNickName(),
                 info.getPostgradu(), info.getMajor(), info.getLab(),
                 profile.getOneLiner(), keyword);
     }
@@ -190,7 +183,7 @@ public class SeniorMapper {
     public static SeniorFieldResponse mapToSeniorField(Senior senior) {
         User user = senior.getUser();
         Info info = senior.getInfo();
-        return new SeniorFieldResponse(user.getProfile(), user.getNickName(),
+        return new SeniorFieldResponse(senior.getSeniorId(), user.getProfile(), user.getNickName(),
                 info.getPostgradu(), info.getMajor(), info.getLab());
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
@@ -4,13 +4,17 @@ import com.postgraduate.domain.account.domain.entity.Account;
 import com.postgraduate.domain.auth.application.dto.req.SeniorChangeRequest;
 import com.postgraduate.domain.auth.application.dto.req.SeniorSignUpRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorMyPageProfileRequest;
-import com.postgraduate.domain.senior.application.dto.res.*;
 import com.postgraduate.domain.senior.application.dto.req.SeniorProfileRequest;
+import com.postgraduate.domain.senior.application.dto.res.*;
 import com.postgraduate.domain.senior.domain.entity.Info;
 import com.postgraduate.domain.senior.domain.entity.Profile;
 import com.postgraduate.domain.senior.domain.entity.Senior;
+import com.postgraduate.domain.senior.domain.entity.constant.Field;
+import com.postgraduate.domain.senior.domain.entity.constant.Postgradu;
 import com.postgraduate.domain.senior.domain.entity.constant.Status;
 import com.postgraduate.domain.user.domain.entity.User;
+
+import java.util.HashSet;
 
 public class SeniorMapper {
 
@@ -23,16 +27,35 @@ public class SeniorMapper {
     }
 
     public static Info mapToInfo(SeniorSignUpRequest request) {
-        return Info.builder()
+        String[] fields = request.field().split(",");
+        HashSet<String> fieldNames = Field.fieldNames();
+        HashSet<String> postgraduNames = Postgradu.postgraduNames();
+
+        Info.InfoBuilder infoBuilder = Info.builder()
                 .major(request.major())
                 .postgradu(request.postgradu())
                 .professor(request.professor())
                 .lab(request.lab())
                 .keyword(request.keyword())
                 .field(request.field())
+                .etcPostgradu(false)
+                .etcPostgradu(false)
                 .totalInfo(request.major() + request.lab() + request.field()
-                        + request.professor() + request.postgradu() + request.field())
-                .build();
+                        + request.professor() + request.postgradu() + request.field());
+
+        for (String field : fields) {
+            if (!fieldNames.contains(field)) {
+                infoBuilder.etcField(true);
+                break;
+            }
+        }
+        for (String postgradu : postgraduNames) {
+            if (!postgraduNames.contains(postgradu)) {
+                infoBuilder.etcPostgradu(true);
+                break;
+            }
+        }
+        return infoBuilder.build();
     }
 
     public static Profile mapToProfile(SeniorProfileRequest profileRequest) {
@@ -64,16 +87,35 @@ public class SeniorMapper {
     }
 
     public static Info mapToInfo(SeniorChangeRequest request) {
-        return Info.builder()
+        String[] fields = request.field().split(",");
+        HashSet<String> fieldNames = Field.fieldNames();
+        HashSet<String> postgraduNames = Postgradu.postgraduNames();
+
+        Info.InfoBuilder infoBuilder = Info.builder()
                 .major(request.major())
                 .postgradu(request.postgradu())
                 .professor(request.professor())
                 .lab(request.lab())
                 .keyword(request.keyword())
                 .field(request.field())
+                .etcPostgradu(false)
+                .etcPostgradu(false)
                 .totalInfo(request.major() + request.lab() + request.field()
-                        + request.professor() + request.postgradu() + request.keyword())
-                .build();
+                        + request.professor() + request.postgradu() + request.field());
+
+        for (String field : fields) {
+            if (!fieldNames.contains(field)) {
+                infoBuilder.etcField(true);
+                break;
+            }
+        }
+        for (String postgradu : postgraduNames) {
+            if (!postgraduNames.contains(postgradu)) {
+                infoBuilder.etcPostgradu(true);
+                break;
+            }
+        }
+        return infoBuilder.build();
     }
 
     public static SeniorMyPageResponse mapToSeniorMyPageInfo(Senior senior, Status certificationRegister, boolean profileRegister) {

--- a/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
@@ -109,12 +109,8 @@ public class SeniorMapper {
                 break;
             }
         }
-        for (String postgradu : postgraduNames) {
-            if (!postgraduNames.contains(postgradu)) {
-                infoBuilder.etcPostgradu(true);
-                break;
-            }
-        }
+        if (!postgraduNames.contains(request.postgradu()))
+            infoBuilder.etcPostgradu(true);
         return infoBuilder.build();
     }
 

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
@@ -38,4 +38,13 @@ public class SeniorInfoUseCase {
         }
         return new AllSeniorSearchResponse(selectSeniors);
     }
+
+    public AllSeniorSearchResponse getFieldSenior(String field, String postgradu, Integer page) {
+        Page<Senior> allSeniors = seniorGetService.byField(field, postgradu, page);
+        List<SeniorSearchResponse> selectSeniors = new ArrayList<>();
+        for (Senior senior : allSeniors.getContent()) {
+            selectSeniors.add(mapToSeniorSearch(senior));
+        }
+        return new AllSeniorSearchResponse(selectSeniors);
+    }
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
@@ -1,8 +1,6 @@
 package com.postgraduate.domain.senior.application.usecase;
 
-import com.postgraduate.domain.senior.application.dto.res.AllSeniorSearchResponse;
-import com.postgraduate.domain.senior.application.dto.res.SeniorDetailResponse;
-import com.postgraduate.domain.senior.application.dto.res.SeniorSearchResponse;
+import com.postgraduate.domain.senior.application.dto.res.*;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
 import com.postgraduate.domain.senior.domain.service.SeniorUpdateService;
@@ -14,8 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.postgraduate.domain.senior.application.mapper.SeniorMapper.mapToSeniorDetail;
-import static com.postgraduate.domain.senior.application.mapper.SeniorMapper.mapToSeniorSearch;
+import static com.postgraduate.domain.senior.application.mapper.SeniorMapper.*;
 
 @Service
 @Transactional
@@ -39,12 +36,12 @@ public class SeniorInfoUseCase {
         return new AllSeniorSearchResponse(selectSeniors);
     }
 
-    public AllSeniorSearchResponse getFieldSenior(String field, String postgradu, Integer page) {
+    public AllSeniorFieldResponse getFieldSenior(String field, String postgradu, Integer page) {
         Page<Senior> allSeniors = seniorGetService.byField(field, postgradu, page);
-        List<SeniorSearchResponse> selectSeniors = new ArrayList<>();
+        List<SeniorFieldResponse> selectSeniors = new ArrayList<>();
         for (Senior senior : allSeniors.getContent()) {
-            selectSeniors.add(mapToSeniorSearch(senior));
+            selectSeniors.add(mapToSeniorField(senior));
         }
-        return new AllSeniorSearchResponse(selectSeniors);
+        return new AllSeniorFieldResponse(selectSeniors);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/domain/entity/Info.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/entity/Info.java
@@ -1,12 +1,16 @@
 package com.postgraduate.domain.senior.domain.entity;
 
 import com.postgraduate.domain.senior.application.dto.req.SeniorMyPageProfileRequest;
+import com.postgraduate.domain.senior.domain.entity.constant.Field;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import static com.postgraduate.domain.senior.domain.entity.constant.Field.fieldNames;
+import static java.util.Arrays.stream;
 
 @Getter
 @AllArgsConstructor
@@ -33,6 +37,10 @@ public class Info {
     private String field;
 
     @Column(nullable = false)
+    @Builder.Default
+    private Boolean etc = false;
+
+    @Column(nullable = false)
     private String totalInfo; // 모든 Info정보 String으로 가지는 컬럼 - 검색시 사용
 
     public void updateMyPage(SeniorMyPageProfileRequest request) {
@@ -40,6 +48,13 @@ public class Info {
         this.lab = request.getLab();
         this.field = request.getField();
         combineTotalInfo();
+    }
+
+    public boolean checkEtc(String fields) {
+        String[] field = fields.split(",");
+        if (stream(field).anyMatch(fieldNames()::contains))
+            return false;
+        return true;
     }
 
     private void combineTotalInfo() {

--- a/src/main/java/com/postgraduate/domain/senior/domain/entity/Info.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/entity/Info.java
@@ -38,7 +38,11 @@ public class Info {
 
     @Column(nullable = false)
     @Builder.Default
-    private Boolean etc = false;
+    private Boolean etcField = false;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean etcPostgradu = false;
 
     @Column(nullable = false)
     private String totalInfo; // 모든 Info정보 String으로 가지는 컬럼 - 검색시 사용
@@ -48,13 +52,6 @@ public class Info {
         this.lab = request.getLab();
         this.field = request.getField();
         combineTotalInfo();
-    }
-
-    public boolean checkEtc(String fields) {
-        String[] field = fields.split(",");
-        if (stream(field).anyMatch(fieldNames()::contains))
-            return false;
-        return true;
     }
 
     private void combineTotalInfo() {

--- a/src/main/java/com/postgraduate/domain/senior/domain/entity/constant/Field.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/entity/constant/Field.java
@@ -1,0 +1,25 @@
+package com.postgraduate.domain.senior.domain.entity.constant;
+
+import java.util.HashSet;
+
+public enum Field {
+    AI("인공지능"), SEMI("반도체"), BIO("바이오"), ENERGY("에너지");
+
+    private final String field;
+
+    public String getField() {
+        return field;
+    }
+
+    Field(String field) {
+        this.field = field;
+    }
+
+    public static HashSet<String> fieldNames() {
+        HashSet<String> fieldNames = new HashSet<>();
+        for (Field field : Field.values()) {
+            fieldNames.add(field.getField());
+        }
+        return fieldNames;
+    }
+}

--- a/src/main/java/com/postgraduate/domain/senior/domain/entity/constant/Postgradu.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/entity/constant/Postgradu.java
@@ -1,0 +1,25 @@
+package com.postgraduate.domain.senior.domain.entity.constant;
+
+import java.util.HashSet;
+
+public enum Postgradu {
+    SEOUL("서울대"), YONSEI("연세대");
+
+    private final String postgradu;
+
+    public String getPostgradu() {
+        return postgradu;
+    }
+
+    Postgradu(String field) {
+        this.postgradu = field;
+    }
+
+    public static HashSet<String> postgraduNames() {
+        HashSet<String> postgraduNames = new HashSet<>();
+        for (Postgradu postgradu : Postgradu.values()) {
+            postgraduNames.add(postgradu.getPostgradu());
+        }
+        return postgraduNames;
+    }
+}

--- a/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepository.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface SeniorDslRepository {
-    Page<Senior> findAllSenior(String search, String sort, Pageable pageable);
+    Page<Senior> findAllBySearchSenior(String search, String sort, Pageable pageable);
+    Page<Senior> findAllByFieldSenior(String field, String postgradu, Pageable pageable);
 }

--- a/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepositoryImpl.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepositoryImpl.java
@@ -73,7 +73,7 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
 
     private BooleanExpression fieldSpecifier(String field) {
         if (field.equals("others"))
-            return senior.info.etc.isTrue();
+            return senior.info.etcField.isTrue();
 
         String[] fields = field.split(",");
         return Arrays.stream(fields)
@@ -83,10 +83,19 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
     }
 
     private BooleanExpression postgraduSpecifier(String postgradu) {
-        if (postgradu.equals("all"))
+        if (postgradu.contains("all"))
             return TRUE;
 
         String[] postgradus = postgradu.split(",");
+
+        if (postgradu.contains("others")) {
+            return Arrays.stream(postgradus)
+                    .map(postgraduName -> senior.info.etcPostgradu.isTrue()
+                            .or(senior.info.postgradu.like("%"+postgraduName+"%")))
+                    .reduce(BooleanExpression::or)
+                    .orElse(FALSE);
+        }
+
         return Arrays.stream(postgradus)
                 .map(postgraduName -> senior.info.postgradu.like("%"+postgraduName+"%"))
                 .reduce(BooleanExpression::or)

--- a/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepositoryImpl.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.postgraduate.domain.senior.domain.repository;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +12,12 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static com.postgraduate.domain.senior.domain.entity.QSenior.senior;
 import static com.postgraduate.domain.senior.domain.entity.constant.Status.APPROVE;
+import static com.querydsl.core.types.dsl.Expressions.TRUE;
 
 @RequiredArgsConstructor
 @Repository
@@ -22,13 +25,13 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Senior> findAllSenior(String search, String sort, Pageable pageable) {
+    public Page<Senior> findAllBySearchSenior(String search, String sort, Pageable pageable) {
         JPAQuery<Senior> query = queryFactory.selectFrom(senior)
-                                                .where(
-                                                        senior.info.totalInfo.like("%" + search + "%"),
-                                                        senior.status.eq(APPROVE)
-                                                )
-                                                .orderBy(orderSpecifier(sort));
+                .where(
+                        senior.info.totalInfo.like("%" + search + "%"),
+                        senior.status.eq(APPROVE)
+                )
+                .orderBy(orderSpecifier(sort));
 
         List<Senior> seniors = query.offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -48,4 +51,42 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
         };
     }
 
+    @Override
+    public Page<Senior> findAllByFieldSenior(String field, String postgradu, Pageable pageable) {
+        String[] fields = field.split(",");
+        String[] postgradus = postgradu.split(",");
+
+        JPAQuery<Senior> query = queryFactory.selectFrom(senior)
+                .where(
+                        fieldSpecifier(fields),
+                        postgraduSpecifier(postgradus),
+                        senior.status.eq(APPROVE)
+                )
+                .orderBy(senior.hit.desc());
+
+        List<Senior> seniors = query.offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = query.fetchCount();
+
+        return new PageImpl<>(seniors, pageable, total);
+    }
+
+    private BooleanExpression fieldSpecifier(String[] fields) {
+        return Arrays.stream(fields)
+                .map(field -> senior.info.field.like("%" + field + "%"))
+                .reduce(BooleanExpression::or)
+                .orElse(TRUE);
+    }
+
+    private BooleanExpression postgraduSpecifier(String[] postgrauds) {
+        if (postgrauds[0].equals("전체")) {
+            return TRUE;
+        }
+        return Arrays.stream(postgrauds)
+                .map(postgradu -> senior.info.postgradu.like("%" + postgradu + "%"))
+                .reduce(BooleanExpression::or)
+                .orElse(TRUE);
+    }
 }

--- a/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepositoryImpl.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepositoryImpl.java
@@ -74,12 +74,7 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
     private BooleanExpression fieldSpecifier(String field) {
         if (field.equals("others"))
             return senior.info.etcField.isTrue();
-
-        String[] fields = field.split(",");
-        return Arrays.stream(fields)
-                .map(fieldName -> senior.info.field.like("%"+fieldName+"%"))
-                .reduce(BooleanExpression::or)
-                .orElse(FALSE);
+        return senior.info.field.like("%"+field+"%");
     }
 
     private BooleanExpression postgraduSpecifier(String postgradu) {

--- a/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorGetService.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorGetService.java
@@ -41,6 +41,14 @@ public class SeniorGetService {
         if (page == null)
             page = 1;
         Pageable pageable = PageRequest.of(page-1, SENIOR_PAGE_SIZE);
-        return seniorRepository.findAllSenior(search, sort, pageable);
+        return seniorRepository.findAllBySearchSenior(search, sort, pageable);
+    }
+
+    public Page<Senior> byField(String field, String postgradu, Integer page) {
+        if (page == null)
+            page = 1;
+        Pageable pageable = PageRequest.of(page-1, SENIOR_PAGE_SIZE);
+        Page<Senior> allByFieldSenior = seniorRepository.findAllByFieldSenior(field, postgradu, pageable);
+        return allByFieldSenior;
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -105,10 +105,10 @@ public class SeniorController {
 
     @GetMapping("/field")
     @Operation(summary = "대학원생 필드 검색")
-    public ResponseDto<AllSeniorSearchResponse> getFieldSenior(@RequestParam String field,
+    public ResponseDto<AllSeniorFieldResponse> getFieldSenior(@RequestParam String field,
                                                                 @RequestParam(required = false) String postgradu,
                                                                 @RequestParam(required = false) Integer page) {
-        AllSeniorSearchResponse searchSenior = seniorInfoUseCase.getFieldSenior(field, postgradu, page);
-        return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_LIST_INFO.getMessage(), searchSenior);
+        AllSeniorFieldResponse fieldSenior = seniorInfoUseCase.getFieldSenior(field, postgradu, page);
+        return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_LIST_INFO.getMessage(), fieldSenior);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -95,7 +95,7 @@ public class SeniorController {
     }
 
     @GetMapping("/search")
-    @Operation(summary = "대학원생 검색어 검색")
+    @Operation(summary = "대학원생 검색어 검색", description = "find 필수, sort 선택 - 안보낼 경우 아예 파라미터 추가x (조회수 낮은순 low, 높은순 high), page선택 (안보내면 기본 1페이지)")
     public ResponseDto<AllSeniorSearchResponse> getSearchSenior(@RequestParam String find,
                                                                 @RequestParam(required = false) String sort,
                                                                 @RequestParam(required = false) Integer page) {
@@ -104,9 +104,9 @@ public class SeniorController {
     }
 
     @GetMapping("/field")
-    @Operation(summary = "대학원생 필드 검색")
+    @Operation(summary = "대학원생 필드 검색", description = "분야 (분야1,분야2 이런식으로, 다른분야 : others), 대학원 필수 (대학원1,대학원2 이런식으로, 다른학교 : others, 전체 : all), 페이지 선택 ")
     public ResponseDto<AllSeniorFieldResponse> getFieldSenior(@RequestParam String field,
-                                                                @RequestParam(required = false) String postgradu,
+                                                                @RequestParam String postgradu,
                                                                 @RequestParam(required = false) Integer page) {
         AllSeniorFieldResponse fieldSenior = seniorInfoUseCase.getFieldSenior(field, postgradu, page);
         return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_LIST_INFO.getMessage(), fieldSenior);

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -102,4 +102,13 @@ public class SeniorController {
         AllSeniorSearchResponse searchSenior = seniorInfoUseCase.getSearchSenior(find, page, sort);
         return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_LIST_INFO.getMessage(), searchSenior);
     }
+
+    @GetMapping("/field")
+    @Operation(summary = "대학원생 필드 검색")
+    public ResponseDto<AllSeniorSearchResponse> getFieldSenior(@RequestParam String field,
+                                                                @RequestParam(required = false) String postgradu,
+                                                                @RequestParam(required = false) Integer page) {
+        AllSeniorSearchResponse searchSenior = seniorInfoUseCase.getFieldSenior(field, postgradu, page);
+        return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_LIST_INFO.getMessage(), searchSenior);
+    }
 }

--- a/src/main/java/com/postgraduate/domain/user/application/dto/res/UserPossibleResponse.java
+++ b/src/main/java/com/postgraduate/domain/user/application/dto/res/UserPossibleResponse.java
@@ -1,0 +1,5 @@
+package com.postgraduate.domain.user.application.dto.res;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UserPossibleResponse(@NotNull Boolean possible, @NotNull Long socialId) {}

--- a/src/main/java/com/postgraduate/domain/user/application/usecase/UserMyPageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/user/application/usecase/UserMyPageUseCase.java
@@ -2,6 +2,7 @@ package com.postgraduate.domain.user.application.usecase;
 
 import com.postgraduate.domain.user.application.dto.res.UserInfoResponse;
 import com.postgraduate.domain.user.application.dto.res.UserMyPageResponse;
+import com.postgraduate.domain.user.application.dto.res.UserPossibleResponse;
 import com.postgraduate.domain.user.application.mapper.UserMapper;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.entity.constant.Role;
@@ -24,10 +25,10 @@ public class UserMyPageUseCase {
         return mapToInfo(user);
     }
 
-    public boolean checkSenior(User user) {
+    public UserPossibleResponse checkSenior(User user) {
         Role role = user.getRole();
         if (role.equals(SENIOR))
-            return true;
-        return false;
+            return new UserPossibleResponse(true, user.getSocialId());
+        return new UserPossibleResponse(false, user.getSocialId());
     }
 }

--- a/src/main/java/com/postgraduate/domain/user/presentation/UserController.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/UserController.java
@@ -3,6 +3,7 @@ package com.postgraduate.domain.user.presentation;
 import com.postgraduate.domain.user.application.dto.req.UserInfoRequest;
 import com.postgraduate.domain.user.application.dto.res.UserInfoResponse;
 import com.postgraduate.domain.user.application.dto.res.UserMyPageResponse;
+import com.postgraduate.domain.user.application.dto.res.UserPossibleResponse;
 import com.postgraduate.domain.user.application.usecase.UserManageUseCase;
 import com.postgraduate.domain.user.application.usecase.UserMyPageUseCase;
 import com.postgraduate.domain.user.domain.entity.User;
@@ -48,9 +49,9 @@ public class UserController {
 
     @GetMapping("/me/role")
     @Operation(summary = "선배 전환시 가능 여부 확인", description = "true-가능, false-불가능")
-    public ResponseDto<Boolean> checkRole(@AuthenticationPrincipal User user) {
-        boolean isOk = myPageUseCase.checkSenior(user);
-        return ResponseDto.create(USER_FIND.getCode(), GET_SENIOR_CHECK.getMessage(), isOk);
+    public ResponseDto<UserPossibleResponse> checkRole(@AuthenticationPrincipal User user) {
+        UserPossibleResponse possibleResponse = myPageUseCase.checkSenior(user);
+        return ResponseDto.create(USER_FIND.getCode(), GET_SENIOR_CHECK.getMessage(), possibleResponse);
     }
 
     @GetMapping("/nickname")


### PR DESCRIPTION
## 🦝 PR 요약
대학원생 분야 필터 추가

## ✨ PR 상세 내용
홈화면 대학원생 분야, 대학원 이용한 필터 기능 추가
- 분야 : 각각 분야 혹은 그 외의 다른 분야 필터링
- 대학원 : 중복 가능하게 대학원 검색 혹은 그 외 다른 대학원 + 전체 대학원 검색

## 🚨 주의 사항
마찬가지로 querydsl사용
senior의 Info값타입에 etcField, etcPostgradu추가 - 그 외인지 확인용 boolean타입

## ✅ 체크 리스트
- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
