### PR TITLE
RAC-230 feat : 회원 탈퇴 기본 로직 구현

### DIFF
--- a/src/main/java/com/postgraduate/domain/auth/application/dto/res/KakaoTokenInfoResponse.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/dto/res/KakaoTokenInfoResponse.java
@@ -1,20 +1,7 @@
 package com.postgraduate.domain.auth.application.dto.res;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotNull;
 
-@Builder
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
-public class KakaoTokenInfoResponse {
-    private String access_token;
-    private String token_type;
-    private String refresh_token;
-    private String id_token;
-    private int expires_in;
-    private String cope;
-    private int refresh_token_expires_in;
+public record KakaoTokenInfoResponse(@NotNull String access_token, @NotNull String token_type, @NotNull String refresh_token, @NotNull String id_token,
+                                     @NotNull int expires_in, @NotNull String cope, @NotNull int refresh_token_expires_in) {
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SelectOauth.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SelectOauth.java
@@ -1,7 +1,7 @@
 package com.postgraduate.domain.auth.application.usecase.oauth;
 
-import com.postgraduate.domain.auth.application.usecase.SignInUseCase;
 import com.postgraduate.domain.auth.application.usecase.oauth.kakao.KakaoSignInUseCase;
+import com.postgraduate.domain.auth.application.usecase.oauth.kakao.KakaoSignOutUseCase;
 import com.postgraduate.domain.auth.exception.OauthException;
 import com.postgraduate.domain.auth.presentation.constant.Provider;
 import lombok.RequiredArgsConstructor;
@@ -13,10 +13,17 @@ import static com.postgraduate.domain.auth.presentation.constant.Provider.KAKAO;
 @Component
 public class SelectOauth {
     private final KakaoSignInUseCase kakaoSignInUseCase;
+    private final KakaoSignOutUseCase kakaoSignOutUseCase;
 
-    public SignInUseCase selectStrategy(Provider provider) {
+    public SignInUseCase selectSignIn(Provider provider) {
         if (provider.equals(KAKAO))
             return kakaoSignInUseCase;
+        throw new OauthException();
+    }
+
+    public SignOutUseCase selectSignOut(Provider provider) {
+        if (provider.equals(KAKAO))
+            return kakaoSignOutUseCase;
         throw new OauthException();
     }
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignInUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignInUseCase.java
@@ -1,4 +1,4 @@
-package com.postgraduate.domain.auth.application.usecase;
+package com.postgraduate.domain.auth.application.usecase.oauth;
 
 import com.postgraduate.domain.auth.application.dto.req.CodeRequest;
 import com.postgraduate.domain.auth.application.dto.res.AuthUserResponse;

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignOutUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignOutUseCase.java
@@ -1,0 +1,5 @@
+package com.postgraduate.domain.auth.application.usecase.oauth;
+
+public interface SignOutUseCase {
+    void signOut(Long userId);
+}

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
@@ -1,4 +1,4 @@
-package com.postgraduate.domain.auth.application.usecase;
+package com.postgraduate.domain.auth.application.usecase.oauth;
 
 import com.postgraduate.domain.auth.application.dto.req.SeniorChangeRequest;
 import com.postgraduate.domain.auth.application.dto.req.SeniorSignUpRequest;

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoAccessTokenUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoAccessTokenUseCase.java
@@ -41,7 +41,7 @@ public class KakaoAccessTokenUseCase {
                     .retrieve()
                     .bodyToMono(KakaoTokenInfoResponse.class)
                     .block();
-            return getUserInfo(tokenInfoResponse.getAccess_token());
+            return getUserInfo(tokenInfoResponse.access_token());
         } catch (WebClientResponseException ex) {
             throw new KakaoCodeException();
         }

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignInUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignInUseCase.java
@@ -4,7 +4,7 @@ import com.postgraduate.domain.auth.application.dto.req.CodeRequest;
 import com.postgraduate.domain.auth.application.dto.res.AuthUserResponse;
 import com.postgraduate.domain.auth.application.dto.res.KakaoUserInfoResponse;
 import com.postgraduate.domain.auth.application.mapper.AuthMapper;
-import com.postgraduate.domain.auth.application.usecase.SignInUseCase;
+import com.postgraduate.domain.auth.application.usecase.oauth.SignInUseCase;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignOutUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignOutUseCase.java
@@ -1,0 +1,58 @@
+package com.postgraduate.domain.auth.application.usecase.oauth.kakao;
+
+import com.postgraduate.domain.auth.application.dto.res.KakaoUserInfoResponse;
+import com.postgraduate.domain.auth.application.usecase.oauth.SignOutUseCase;
+import com.postgraduate.domain.auth.exception.KakaoException;
+import com.postgraduate.domain.user.domain.entity.User;
+import com.postgraduate.domain.user.domain.service.UserGetService;
+import com.postgraduate.domain.user.domain.service.UserUpdateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class KakaoSignOutUseCase implements SignOutUseCase {
+    private final WebClient webClient;
+    private final UserUpdateService userUpdateService;
+    private final UserGetService userGetService;
+
+    @Value("${admin-id.kakao}")
+    private String ADMIN_ID;
+    private static final String AUTHORIZATION = "KakaoAK ";
+    private static final String KAKAO_UNLINK_URI = "https://kapi.kakao.com/v1/user/unlink";
+
+    @Override
+    public void signOut(Long userId) {
+        try {
+            User user = userGetService.getUser(userId);
+            MultiValueMap<String, String> requestBody = getRequestBody(user.getSocialId());
+            webClient.post()
+                    .uri(KAKAO_UNLINK_URI)
+                    .headers(h -> h.setContentType(MediaType.APPLICATION_FORM_URLENCODED))
+                    .headers(h -> h.set(HttpHeaders.AUTHORIZATION, AUTHORIZATION + ADMIN_ID))
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+            userUpdateService.updateDelete(user.getUserId());
+        } catch (WebClientResponseException ex) {
+            throw new KakaoException();
+        }
+    }
+
+    private MultiValueMap<String, String> getRequestBody(Long socialId) {
+        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+        requestBody.add("target_id_type", "user_id");
+        requestBody.add("target_id", socialId.toString());
+        return requestBody;
+    }
+}

--- a/src/main/java/com/postgraduate/domain/auth/presentation/constant/AuthResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/constant/AuthResponseMessage.java
@@ -10,6 +10,7 @@ public enum AuthResponseMessage {
     NOT_REGISTERED_USER("가입하지 않은 유저입니다."),
     SUCCESS_REGENERATE_TOKEN("토큰 재발급에 성공하였습니다."),
     LOGOUT_USER("로그아웃에 성공하였습니다."),
+    SIGNOUT_USER("회원탈퇴에 성공하였습니다."),
 
     PERMISSION_DENIED("권한이 없습니다."),
     KAKAO_INVALID("카카오 정보가 유효하지 않습니다."),

--- a/src/main/java/com/postgraduate/domain/user/domain/entity/User.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/entity/User.java
@@ -53,6 +53,10 @@ public class User {
     @UpdateTimestamp
     private LocalDate updatedAt;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean isDelete = false;
+
     public void updateRole(Role role) {
         this.role = role;
     }
@@ -61,5 +65,9 @@ public class User {
         this.profile = profile;
         this.nickName = nickName;
         this.phoneNumber = phoneNumber;
+    }
+
+    public void updateDelete() {
+        this.isDelete = true;
     }
 }

--- a/src/main/java/com/postgraduate/domain/user/domain/service/UserUpdateService.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/service/UserUpdateService.java
@@ -14,6 +14,11 @@ import org.springframework.stereotype.Service;
 public class UserUpdateService {
     private final UserRepository userRepository;
 
+    public void updateDelete(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        user.updateDelete();
+    }
+
     public void updateRole(Long userId, Role role) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         user.updateRole(role);


### PR DESCRIPTION
## 🦝 PR 요약
회원 탈퇴 기본 로직 구현 -> 그 외에 회원 관련해서 해야할 수정은 아직 안함!

## ✨ PR 상세 내용
회원 탈퇴 요청시 기존 소셜과 연결을 끊어줌
-> 이후에 로그인을 원할 경우 다시 동의부터 해야함

User에 isDelete컬럼이 추가되었습니다 -> 탈퇴 상태 확인용! false는 정상 회원, true는 탈퇴 회원

## 🚨 주의 사항
단순히 끊기만 되어있는 부분이라 이외에 수정할 부분은 다른 브랜치에서 작업 예정입니다!
-> 좀 많을 것 같아서 이부분 먼저 pr날리고 다른 부분은 따로 처리하겠습니다~

## ✅ 체크 리스트
- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
