### PR TITLE
RAC-224 fix : 회원 탈퇴 로직 추가 및 기존 조회 수정

### DIFF
--- a/src/main/java/com/postgraduate/domain/admin/application/usecase/SalaryManageByAdminUseCase.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/usecase/SalaryManageByAdminUseCase.java
@@ -53,14 +53,14 @@ public class SalaryManageByAdminUseCase {
     public SalaryManageResponse getSalaries() {
         List<SalaryInfo> responses = new ArrayList<>();
         List<Senior> seniors = seniorGetService.all();
-        for (Senior senior : seniors) {
-            List<Salary> salaries = salaryGetService.bySeniorAndSalaryDateAndStatus(senior, getSalaryDate(), true);
-            if (getStatus(salaries) != DONE) {
-                continue;
-            }
+        seniors.forEach(senior -> {
+            List<Salary> salaries = salaryGetService.bySeniorAndSalaryDateAndStatus(senior, getSalaryDate(), true)
+                    .stream()
+                    .filter(salary -> (salary.getStatus().equals(DONE)))
+                    .toList();
             SalaryInfo response = getSalaryInfo(senior, salaries);
             responses.add(response);
-        }
+        });
         return new SalaryManageResponse(responses);
     }
 
@@ -80,8 +80,6 @@ public class SalaryManageByAdminUseCase {
     public void updateSalaryStatus(Long seniorId, Boolean status) {
         Senior senior = seniorGetService.bySeniorId(seniorId);
         List<Salary> salaries = salaryGetService.bySeniorAndSalaryDate(senior, getSalaryDate());
-        for (Salary salary : salaries) {
-            salaryUpdateService.updateStatus(salary, status);
-        }
+        salaries.forEach(salary -> salaryUpdateService.updateStatus(salary, status));
     }
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/dto/res/KakaoTokenInfoResponse.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/dto/res/KakaoTokenInfoResponse.java
@@ -1,20 +1,7 @@
 package com.postgraduate.domain.auth.application.dto.res;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotNull;
 
-@Builder
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
-public class KakaoTokenInfoResponse {
-    private String access_token;
-    private String token_type;
-    private String refresh_token;
-    private String id_token;
-    private int expires_in;
-    private String cope;
-    private int refresh_token_expires_in;
+public record KakaoTokenInfoResponse(@NotNull String access_token, @NotNull String token_type, @NotNull String refresh_token, @NotNull String id_token,
+                                     @NotNull int expires_in, @NotNull String cope, @NotNull int refresh_token_expires_in) {
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/jwt/JwtUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/jwt/JwtUseCase.java
@@ -2,6 +2,7 @@ package com.postgraduate.domain.auth.application.usecase.jwt;
 
 import com.postgraduate.domain.auth.application.dto.res.JwtTokenResponse;
 import com.postgraduate.domain.user.domain.entity.User;
+import com.postgraduate.domain.user.exception.DeletedUserException;
 import com.postgraduate.global.config.security.jwt.util.JwtUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -26,11 +27,15 @@ public class JwtUseCase {
     }
 
     public JwtTokenResponse regenerateToken(User user, HttpServletRequest request) {
+        if (user.getIsDelete())
+            throw new DeletedUserException();
         jwtUtils.checkRedis(user.getUserId(), request);
         return generateToken(user);
     }
 
     private JwtTokenResponse generateToken(User user) {
+        if (user.getIsDelete())
+            throw new DeletedUserException();
         String accessToken = jwtUtils.generateAccessToken(user.getUserId(), user.getRole());
         String refreshToken = jwtUtils.generateRefreshToken(user.getUserId(), user.getRole());
         return new JwtTokenResponse(accessToken, accessExpiration, refreshToken, refreshExpiration, user.getRole());

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SelectOauth.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SelectOauth.java
@@ -1,7 +1,7 @@
 package com.postgraduate.domain.auth.application.usecase.oauth;
 
-import com.postgraduate.domain.auth.application.usecase.SignInUseCase;
 import com.postgraduate.domain.auth.application.usecase.oauth.kakao.KakaoSignInUseCase;
+import com.postgraduate.domain.auth.application.usecase.oauth.kakao.KakaoSignOutUseCase;
 import com.postgraduate.domain.auth.exception.OauthException;
 import com.postgraduate.domain.auth.presentation.constant.Provider;
 import lombok.RequiredArgsConstructor;
@@ -13,10 +13,17 @@ import static com.postgraduate.domain.auth.presentation.constant.Provider.KAKAO;
 @Component
 public class SelectOauth {
     private final KakaoSignInUseCase kakaoSignInUseCase;
+    private final KakaoSignOutUseCase kakaoSignOutUseCase;
 
-    public SignInUseCase selectStrategy(Provider provider) {
+    public SignInUseCase selectSignIn(Provider provider) {
         if (provider.equals(KAKAO))
             return kakaoSignInUseCase;
+        throw new OauthException();
+    }
+
+    public SignOutUseCase selectSignOut(Provider provider) {
+        if (provider.equals(KAKAO))
+            return kakaoSignOutUseCase;
         throw new OauthException();
     }
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignInUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignInUseCase.java
@@ -1,4 +1,4 @@
-package com.postgraduate.domain.auth.application.usecase;
+package com.postgraduate.domain.auth.application.usecase.oauth;
 
 import com.postgraduate.domain.auth.application.dto.req.CodeRequest;
 import com.postgraduate.domain.auth.application.dto.res.AuthUserResponse;

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignOutUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignOutUseCase.java
@@ -1,0 +1,5 @@
+package com.postgraduate.domain.auth.application.usecase.oauth;
+
+public interface SignOutUseCase {
+    void signOut(Long userId);
+}

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
@@ -1,4 +1,4 @@
-package com.postgraduate.domain.auth.application.usecase;
+package com.postgraduate.domain.auth.application.usecase.oauth;
 
 import com.postgraduate.domain.auth.application.dto.req.SeniorChangeRequest;
 import com.postgraduate.domain.auth.application.dto.req.SeniorSignUpRequest;

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoAccessTokenUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoAccessTokenUseCase.java
@@ -41,7 +41,7 @@ public class KakaoAccessTokenUseCase {
                     .retrieve()
                     .bodyToMono(KakaoTokenInfoResponse.class)
                     .block();
-            return getUserInfo(tokenInfoResponse.getAccess_token());
+            return getUserInfo(tokenInfoResponse.access_token());
         } catch (WebClientResponseException ex) {
             throw new KakaoCodeException();
         }

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignInUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignInUseCase.java
@@ -4,7 +4,7 @@ import com.postgraduate.domain.auth.application.dto.req.CodeRequest;
 import com.postgraduate.domain.auth.application.dto.res.AuthUserResponse;
 import com.postgraduate.domain.auth.application.dto.res.KakaoUserInfoResponse;
 import com.postgraduate.domain.auth.application.mapper.AuthMapper;
-import com.postgraduate.domain.auth.application.usecase.SignInUseCase;
+import com.postgraduate.domain.auth.application.usecase.oauth.SignInUseCase;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignOutUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignOutUseCase.java
@@ -1,0 +1,58 @@
+package com.postgraduate.domain.auth.application.usecase.oauth.kakao;
+
+import com.postgraduate.domain.auth.application.dto.res.KakaoUserInfoResponse;
+import com.postgraduate.domain.auth.application.usecase.oauth.SignOutUseCase;
+import com.postgraduate.domain.auth.exception.KakaoException;
+import com.postgraduate.domain.user.domain.entity.User;
+import com.postgraduate.domain.user.domain.service.UserGetService;
+import com.postgraduate.domain.user.domain.service.UserUpdateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class KakaoSignOutUseCase implements SignOutUseCase {
+    private final WebClient webClient;
+    private final UserUpdateService userUpdateService;
+    private final UserGetService userGetService;
+
+    @Value("${admin-id.kakao}")
+    private String ADMIN_ID;
+    private static final String AUTHORIZATION = "KakaoAK ";
+    private static final String KAKAO_UNLINK_URI = "https://kapi.kakao.com/v1/user/unlink";
+
+    @Override
+    public void signOut(Long userId) {
+        try {
+            User user = userGetService.getUser(userId);
+            MultiValueMap<String, String> requestBody = getRequestBody(user.getSocialId());
+            webClient.post()
+                    .uri(KAKAO_UNLINK_URI)
+                    .headers(h -> h.setContentType(MediaType.APPLICATION_FORM_URLENCODED))
+                    .headers(h -> h.set(HttpHeaders.AUTHORIZATION, AUTHORIZATION + ADMIN_ID))
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+            userUpdateService.updateDelete(user.getUserId());
+        } catch (WebClientResponseException ex) {
+            throw new KakaoException();
+        }
+    }
+
+    private MultiValueMap<String, String> getRequestBody(Long socialId) {
+        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+        requestBody.add("target_id_type", "user_id");
+        requestBody.add("target_id", socialId.toString());
+        return requestBody;
+    }
+}

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignOutUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignOutUseCase.java
@@ -1,11 +1,11 @@
 package com.postgraduate.domain.auth.application.usecase.oauth.kakao;
 
-import com.postgraduate.domain.auth.application.dto.res.KakaoUserInfoResponse;
 import com.postgraduate.domain.auth.application.usecase.oauth.SignOutUseCase;
 import com.postgraduate.domain.auth.exception.KakaoException;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.service.UserGetService;
 import com.postgraduate.domain.user.domain.service.UserUpdateService;
+import com.postgraduate.global.config.security.jwt.util.JwtUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -24,6 +24,7 @@ public class KakaoSignOutUseCase implements SignOutUseCase {
     private final WebClient webClient;
     private final UserUpdateService userUpdateService;
     private final UserGetService userGetService;
+    private final JwtUtils jwtUtils;
 
     @Value("${admin-id.kakao}")
     private String ADMIN_ID;
@@ -44,6 +45,7 @@ public class KakaoSignOutUseCase implements SignOutUseCase {
                     .bodyToMono(String.class)
                     .block();
             userUpdateService.updateDelete(user.getUserId());
+            jwtUtils.makeExpired(userId);
         } catch (WebClientResponseException ex) {
             throw new KakaoException();
         }

--- a/src/main/java/com/postgraduate/domain/auth/presentation/constant/AuthResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/constant/AuthResponseMessage.java
@@ -10,6 +10,7 @@ public enum AuthResponseMessage {
     NOT_REGISTERED_USER("가입하지 않은 유저입니다."),
     SUCCESS_REGENERATE_TOKEN("토큰 재발급에 성공하였습니다."),
     LOGOUT_USER("로그아웃에 성공하였습니다."),
+    SIGNOUT_USER("회원탈퇴에 성공하였습니다."),
 
     PERMISSION_DENIED("권한이 없습니다."),
     KAKAO_INVALID("카카오 정보가 유효하지 않습니다."),

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/CheckIsMyMentoringUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/CheckIsMyMentoringUseCase.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class CheckIsMyMentoringUseCase {
-    private final SeniorGetService seniorGetService;
     private final MentoringGetService mentoringGetService;
 
     public Mentoring byUser(User user, Long mentoringId) {

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseCase.java
@@ -85,11 +85,11 @@ public class MentoringManageUseCase {
     public void updateCancel() {
         LocalDate now = LocalDate.now();
         List<Mentoring> mentorings = mentoringGetService.byStatusAndCreatedAt(WAITING, now);
-        for (Mentoring mentoring : mentorings) {
-            mentoringUpdateService.updateStatus(mentoring, CANCEL);
-            Refuse refuse = RefuseMapper.mapToRefuse(mentoring);
-            refuseSaveService.saveRefuse(refuse);
-            //TODO : 알림 보내거나 나머지 작업
-        }
+        mentorings.forEach(mentoring -> {
+                    mentoringUpdateService.updateStatus(mentoring, CANCEL);
+                    Refuse refuse = RefuseMapper.mapToRefuse(mentoring);
+                    refuseSaveService.saveRefuse(refuse);
+                    //TODO : 알림 보내거나 나머지 작업
+                });
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCase.java
@@ -5,6 +5,7 @@ import com.postgraduate.domain.mentoring.application.dto.ExpectedMentoringInfo;
 import com.postgraduate.domain.mentoring.application.dto.WaitingMentoringInfo;
 import com.postgraduate.domain.mentoring.application.dto.res.AppliedMentoringDetailResponse;
 import com.postgraduate.domain.mentoring.application.dto.res.AppliedMentoringResponse;
+import com.postgraduate.domain.mentoring.application.mapper.MentoringMapper;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.mentoring.domain.service.MentoringGetService;
 import com.postgraduate.domain.mentoring.exception.MentoringDoneException;
@@ -13,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.postgraduate.domain.mentoring.application.mapper.MentoringMapper.*;
@@ -36,28 +36,25 @@ public class MentoringUserInfoUseCase {
 
     public AppliedMentoringResponse getWaiting(User user) {
         List<Mentoring> mentorings = mentoringGetService.mentoringByUser(user, WAITING);
-        List<WaitingMentoringInfo> waitingMentoringInfos = new ArrayList<>();
-        for (Mentoring mentoring : mentorings) {
-            waitingMentoringInfos.add(mapToWaitingInfo(mentoring));
-        }
+        List<WaitingMentoringInfo> waitingMentoringInfos = mentorings.stream()
+                .map(MentoringMapper::mapToWaitingInfo)
+                .toList();
         return new AppliedMentoringResponse(waitingMentoringInfos);
     }
 
     public AppliedMentoringResponse getExpected(User user) {
         List<Mentoring> mentorings = mentoringGetService.mentoringByUser(user, EXPECTED);
-        List<ExpectedMentoringInfo> expectedMentoringInfos = new ArrayList<>();
-        for (Mentoring mentoring : mentorings) {
-            expectedMentoringInfos.add(mapToExpectedInfo(mentoring));
-        }
+        List<ExpectedMentoringInfo> expectedMentoringInfos = mentorings.stream()
+                .map(MentoringMapper::mapToExpectedInfo)
+                .toList();
         return new AppliedMentoringResponse(expectedMentoringInfos);
     }
 
     public AppliedMentoringResponse getDone(User user) {
         List<Mentoring> mentorings = mentoringGetService.mentoringByUser(user, DONE);
-        List<DoneMentoringInfo> doneMentoringInfos = new ArrayList<>();
-        for (Mentoring mentoring : mentorings) {
-            doneMentoringInfos.add(mapToDoneInfo(mentoring));
-        }
+        List<DoneMentoringInfo> doneMentoringInfos = mentorings.stream()
+                .map(MentoringMapper::mapToDoneInfo)
+                .toList();
         return new AppliedMentoringResponse(doneMentoringInfos);
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
@@ -12,8 +12,8 @@ import java.util.Optional;
 
 public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
     Optional<Mentoring> findByMentoringId(Long mentoringId);
-    List<Mentoring> findAllByUserAndStatus(User user, Status status);
-    List<Mentoring> findAllBySeniorAndStatus(Senior senior, Status status);
+    List<Mentoring> findAllByUserAndStatusAndSenior_User_IsDelete(User user, Status status, Boolean isDelete);
+    List<Mentoring> findAllBySeniorAndStatusAndUser_IsDelete(Senior senior, Status status, Boolean isDelete);
     List<Mentoring> findAllByStatusAndCreatedAtIsBefore(Status status, LocalDate now);
     List<Mentoring> findAllByUser_UserId(Long userId);
     List<Mentoring> findAllBySenior_SeniorId(Long seniorId);

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
-    Optional<Mentoring> findByMentoringId(Long mentoringId);
+    Optional<Mentoring> findByMentoringIdAndUser_IsDeleteAndSenior_User_IsDelete(Long mentoringId, Boolean isUserDelete, Boolean isSeniorDelete);
     List<Mentoring> findAllByUserAndStatusAndSenior_User_IsDelete(User user, Status status, Boolean isDelete);
     List<Mentoring> findAllBySeniorAndStatusAndUser_IsDelete(Senior senior, Status status, Boolean isDelete);
     List<Mentoring> findAllByStatusAndCreatedAtIsBefore(Status status, LocalDate now);

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
@@ -12,8 +12,8 @@ import java.util.Optional;
 
 public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
     Optional<Mentoring> findByMentoringIdAndUser_IsDeleteAndSenior_User_IsDelete(Long mentoringId, Boolean isUserDelete, Boolean isSeniorDelete);
-    List<Mentoring> findAllByUserAndStatusAndSenior_User_IsDelete(User user, Status status, Boolean isDelete);
-    List<Mentoring> findAllBySeniorAndStatusAndUser_IsDelete(Senior senior, Status status, Boolean isDelete);
+    List<Mentoring> findAllByUserAndStatus(User user, Status status);
+    List<Mentoring> findAllBySeniorAndStatus(Senior senior, Status status);
     List<Mentoring> findAllByStatusAndCreatedAtIsBefore(Status status, LocalDate now);
     List<Mentoring> findAllByUser_UserId(Long userId);
     List<Mentoring> findAllBySenior_SeniorId(Long seniorId);

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
@@ -12,17 +12,19 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.List;
 
+import static java.lang.Boolean.FALSE;
+
 @Service
 @RequiredArgsConstructor
 public class MentoringGetService {
     private final MentoringRepository mentoringRepository;
 
     public List<Mentoring> mentoringByUser(User user, Status status) {
-        return mentoringRepository.findAllByUserAndStatus(user, status);
+        return mentoringRepository.findAllByUserAndStatusAndSenior_User_IsDelete(user, status, FALSE);
     }
 
     public List<Mentoring> mentoringBySenior(Senior senior, Status status) {
-        return mentoringRepository.findAllBySeniorAndStatus(senior, status);
+        return mentoringRepository.findAllBySeniorAndStatusAndUser_IsDelete(senior, status, FALSE);
     }
 
     public Mentoring byMentoringId(Long mentoringId) {

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
@@ -28,7 +28,8 @@ public class MentoringGetService {
     }
 
     public Mentoring byMentoringId(Long mentoringId) {
-        return mentoringRepository.findByMentoringId(mentoringId).orElseThrow(MentoringNotFoundException::new);
+        return mentoringRepository.findByMentoringIdAndUser_IsDeleteAndSenior_User_IsDelete(mentoringId, FALSE, FALSE)
+                .orElseThrow(MentoringNotFoundException::new);
     }
 
     public List<Mentoring> byStatusAndCreatedAt(Status status, LocalDate now) {

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
@@ -20,11 +20,11 @@ public class MentoringGetService {
     private final MentoringRepository mentoringRepository;
 
     public List<Mentoring> mentoringByUser(User user, Status status) {
-        return mentoringRepository.findAllByUserAndStatusAndSenior_User_IsDelete(user, status, FALSE);
+        return mentoringRepository.findAllByUserAndStatus(user, status);
     }
 
     public List<Mentoring> mentoringBySenior(Senior senior, Status status) {
-        return mentoringRepository.findAllBySeniorAndStatusAndUser_IsDelete(senior, status, FALSE);
+        return mentoringRepository.findAllBySeniorAndStatus(senior, status);
     }
 
     public Mentoring byMentoringId(Long mentoringId) {

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
@@ -10,7 +10,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.postgraduate.domain.senior.application.mapper.SeniorMapper.*;
@@ -29,20 +28,18 @@ public class SeniorInfoUseCase {
     }
 
     public AllSeniorSearchResponse getSearchSenior(String search, Integer page, String sort) {
-        Page<Senior> allSeniors = seniorGetService.bySearch(search, page, sort);
-        List<SeniorSearchResponse> selectSeniors = new ArrayList<>();
-        for (Senior senior : allSeniors.getContent()) {
-            selectSeniors.add(mapToSeniorSearch(senior));
-        }
+        Page<Senior> seniors = seniorGetService.bySearch(search, page, sort);
+        List<SeniorSearchResponse> selectSeniors = seniors.stream()
+                .map(SeniorMapper::mapToSeniorSearch)
+                .toList();
         return new AllSeniorSearchResponse(selectSeniors);
     }
 
     public AllSeniorSearchResponse getFieldSenior(String field, String postgradu, Integer page) {
-        Page<Senior> allSeniors = seniorGetService.byField(field, postgradu, page);
-        List<SeniorSearchResponse> selectSeniors = new ArrayList<>();
-        for (Senior senior : allSeniors.getContent()) {
-            selectSeniors.add(mapToSeniorSearch(senior));
-        }
+        Page<Senior> seniors = seniorGetService.byField(field, postgradu, page);
+        List<SeniorSearchResponse> selectSeniors = seniors.stream()
+                .map(SeniorMapper::mapToSeniorSearch)
+                .toList();
         return new AllSeniorSearchResponse(selectSeniors);
     }
 

--- a/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepositoryImpl.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepositoryImpl.java
@@ -32,7 +32,8 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
         JPAQuery<Senior> query = queryFactory.selectFrom(senior)
                 .where(
                         senior.info.totalInfo.like("%" + search + "%"),
-                        senior.status.eq(APPROVE)
+                        senior.status.eq(APPROVE),
+                        senior.user.isDelete.eq(FALSE)
                 )
                 .orderBy(orderSpecifier(sort))
                 .orderBy(senior.user.nickName.asc());
@@ -60,7 +61,8 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
                 .where(
                         fieldSpecifier(field),
                         postgraduSpecifier(postgradu),
-                        senior.status.eq(APPROVE)
+                        senior.status.eq(APPROVE),
+                        senior.user.isDelete.eq(FALSE)
                 )
                 .orderBy(senior.hit.desc())
                 .orderBy(senior.user.nickName.asc());

--- a/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorRepository.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 
 public interface SeniorRepository extends JpaRepository<Senior, Long>, SeniorDslRepository {
     Optional<Senior> findByUser(User user);
-    Optional<Senior> findBySeniorIdAndProfileNotNullAndStatus(Long seniorId, Status status);
+    Optional<Senior> findBySeniorIdAndUser_IsDelete(Long seniorId, Boolean isDelete);
+    Optional<Senior> findBySeniorIdAndProfileNotNullAndStatusAndUser_IsDelete(Long seniorId, Status status, Boolean isDelete);
     List<Senior> findAllByStatus(Status status);
+    List<Senior> findAllByUser_IsDelete(Boolean isDelete);
 }

--- a/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorGetService.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorGetService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 import static com.postgraduate.domain.senior.domain.entity.constant.Status.APPROVE;
+import static java.lang.Boolean.FALSE;
 
 @Service
 @RequiredArgsConstructor
@@ -26,11 +27,11 @@ public class SeniorGetService {
     }
 
     public Senior bySeniorId(Long seniorId) {
-        return seniorRepository.findById(seniorId).orElseThrow(NoneSeniorException::new);
+        return seniorRepository.findBySeniorIdAndUser_IsDelete(seniorId, FALSE).orElseThrow(NoneSeniorException::new);
     }
 
     public Senior bySeniorIdWithCertification(Long seniorId) {
-        return seniorRepository.findBySeniorIdAndProfileNotNullAndStatus(seniorId, APPROVE).orElseThrow(NoneSeniorException::new);
+        return seniorRepository.findBySeniorIdAndProfileNotNullAndStatusAndUser_IsDelete(seniorId, APPROVE, FALSE).orElseThrow(NoneSeniorException::new);
     }
 
     public List<Senior> byStatus(Status status) {
@@ -38,7 +39,7 @@ public class SeniorGetService {
     }
 
     public List<Senior> all() {
-        return seniorRepository.findAll();
+        return seniorRepository.findAllByUser_IsDelete(FALSE);
     }
 
     public Page<Senior> bySearch(String search, Integer page, String sort) {

--- a/src/main/java/com/postgraduate/domain/user/domain/entity/User.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/entity/User.java
@@ -53,6 +53,10 @@ public class User {
     @UpdateTimestamp
     private LocalDate updatedAt;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean isDelete = false;
+
     public void updateRole(Role role) {
         this.role = role;
     }
@@ -61,5 +65,9 @@ public class User {
         this.profile = profile;
         this.nickName = nickName;
         this.phoneNumber = phoneNumber;
+    }
+
+    public void updateDelete() {
+        this.isDelete = true;
     }
 }

--- a/src/main/java/com/postgraduate/domain/user/domain/service/UserUpdateService.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/service/UserUpdateService.java
@@ -14,6 +14,11 @@ import org.springframework.stereotype.Service;
 public class UserUpdateService {
     private final UserRepository userRepository;
 
+    public void updateDelete(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        user.updateDelete();
+    }
+
     public void updateRole(Long userId, Role role) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         user.updateRole(role);

--- a/src/main/java/com/postgraduate/domain/user/exception/DeletedUserException.java
+++ b/src/main/java/com/postgraduate/domain/user/exception/DeletedUserException.java
@@ -1,0 +1,10 @@
+package com.postgraduate.domain.user.exception;
+
+import com.postgraduate.domain.user.presentation.constant.UserResponseCode;
+import com.postgraduate.domain.user.presentation.constant.UserResponseMessage;
+
+public class DeletedUserException extends UserException{
+    public DeletedUserException() {
+        super(UserResponseMessage.DELETED_USER.getMessage(), UserResponseCode.DELETED_USER.getCode());
+    }
+}

--- a/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseCode.java
@@ -11,6 +11,7 @@ public enum UserResponseCode {
     USER_CREATE("UR202"),
     USER_DELETE("UR203"),
 
-    USER_NOT_FOUND("EX300");
+    USER_NOT_FOUND("EX300"),
+    DELETED_USER("EX301");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseMessage.java
@@ -12,7 +12,8 @@ public enum UserResponseMessage {
     GET_SENIOR_CHECK("선배 변환 가능 여부 조회에 성공하였습니다."),
     UPDATE_USER_INFO("사용자 업데이트에 성공하였습니다."),
 
-    NOT_FOUND_USER("등록된 사용자가 없습니다.");
+    NOT_FOUND_USER("등록된 사용자가 없습니다."),
+    DELETED_USER("탈퇴한 사용자 입니다.");
 
     private final String message;
 }

--- a/src/main/java/com/postgraduate/domain/wish/domain/repository/WishRepository.java
+++ b/src/main/java/com/postgraduate/domain/wish/domain/repository/WishRepository.java
@@ -4,8 +4,10 @@ import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.wish.domain.entity.Wish;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface WishRepository extends JpaRepository<Wish, Long> {
     Optional<Wish> findByUser(User user);
+    List<Wish> findAllByUser_IsDelete(boolean isDelete);
 }

--- a/src/main/java/com/postgraduate/domain/wish/domain/service/WishGetService.java
+++ b/src/main/java/com/postgraduate/domain/wish/domain/service/WishGetService.java
@@ -23,6 +23,6 @@ public class WishGetService {
     }
 
     public List<Wish> all() {
-        return wishRepository.findAll();
+        return wishRepository.findAllByUser_IsDelete(false);
     }
 }


### PR DESCRIPTION
## 🦝 PR 요약
- 회원 탈퇴 기본 로직 구현
- 탈퇴 회원 고려 조회 로직 수정 및 일부 리펙토링

## ✨ PR 상세 내용
- 회원 탈퇴 요청시 기존 소셜과 연결을 끊어줌
-> 이후에 로그인을 원할 경우 다시 동의부터 해야함

- 기존의 for문을 Collection.forEach혹은 stream 활용으로 변경 (다만 가독성 고려하여 일부분 유지한 부분도 있음)
- 탈퇴 회원 토큰 발급X 예외 출력
- 삭제된 후배, 선배 조회 못하도록 수정 (상세조회, 전체 리스트 조회 등등)

## 🚨 주의 사항
멘토링 WAITING, EXPECTED, DONE에서 상대방이 탈퇴하면 해당 멘토링이 보임 - 안보이게 할 수 있지만,
어떤게 올바른 선택인지 모르겠어서 일단은 상세 조회만 막아놓음. 내가 진행한 내역은 볼 수 있는게 옳다고 생각함 (기획이 말하면 바꿀게요!)

User에 isDelete컬럼이 추가되었습니다 -> 탈퇴 상태 확인용! false는 정상 회원, true는 탈퇴 회원

탈퇴 유저에 대한 필터링을 하다 보니 메소드 길이가 너무 길어져서 querydsl등 다른 방식을 생각해볼 필요가 있을 것 같음
어짜피 n+1 문제 등등 고려한다면 이후에 querydsl을 사용할 가능성 또한 존재하기도 함

## ✅ 체크 리스트
- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
