### PR TITLE
RAC-232 fix : 기존 대학원생 가능 시간 정보 로직 수정

### DIFF
--- a/src/main/java/com/postgraduate/domain/admin/application/mapper/AdminMapper.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/mapper/AdminMapper.java
@@ -147,7 +147,7 @@ public class AdminMapper {
                 senior.getUser().getNickName(),
                 senior.getUser().getPhoneNumber(),
                 mentoring.getDate(),
-                senior.getProfile().getTerm(),
+                mentoring.getTerm(),
                 (int) (mentoring.getPay() * 1.2),
                 (int) (mentoring.getPay() * 0.2)
         );

--- a/src/main/java/com/postgraduate/domain/available/application/dto/req/AvailableCreateRequest.java
+++ b/src/main/java/com/postgraduate/domain/available/application/dto/req/AvailableCreateRequest.java
@@ -1,0 +1,5 @@
+package com.postgraduate.domain.available.application.dto.req;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AvailableCreateRequest(@NotNull String day, @NotNull String startTime, @NotNull String endTime) {}

--- a/src/main/java/com/postgraduate/domain/available/application/dto/res/AvailableTimeResponse.java
+++ b/src/main/java/com/postgraduate/domain/available/application/dto/res/AvailableTimeResponse.java
@@ -1,0 +1,5 @@
+package com.postgraduate.domain.available.application.dto.res;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AvailableTimeResponse (@NotNull String day, @NotNull String startTime, @NotNull String endTime){}

--- a/src/main/java/com/postgraduate/domain/available/application/dto/res/AvailableTimesResponse.java
+++ b/src/main/java/com/postgraduate/domain/available/application/dto/res/AvailableTimesResponse.java
@@ -1,0 +1,7 @@
+package com.postgraduate.domain.available.application.dto.res;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record AvailableTimesResponse (@NotNull List<AvailableTimeResponse> times){}

--- a/src/main/java/com/postgraduate/domain/available/application/mapper/AvailableMapper.java
+++ b/src/main/java/com/postgraduate/domain/available/application/mapper/AvailableMapper.java
@@ -1,0 +1,21 @@
+package com.postgraduate.domain.available.application.mapper;
+
+import com.postgraduate.domain.available.application.dto.req.AvailableCreateRequest;
+import com.postgraduate.domain.available.application.dto.res.AvailableTimeResponse;
+import com.postgraduate.domain.available.domain.entity.Available;
+import com.postgraduate.domain.senior.domain.entity.Senior;
+
+public class AvailableMapper {
+    public static Available mapToAvailable(Senior senior, AvailableCreateRequest createRequest) {
+        return Available.builder()
+                .senior(senior)
+                .day(createRequest.day())
+                .startTime(createRequest.startTime())
+                .endTime(createRequest.endTime())
+                .build();
+    }
+
+    public static AvailableTimeResponse mapToAvailableTimes(Available available) {
+        return new AvailableTimeResponse(available.getDay(), available.getStartTime(), available.getEndTime());
+    }
+}

--- a/src/main/java/com/postgraduate/domain/available/domain/entity/Available.java
+++ b/src/main/java/com/postgraduate/domain/available/domain/entity/Available.java
@@ -1,0 +1,32 @@
+package com.postgraduate.domain.available.domain.entity;
+
+import com.postgraduate.domain.available.application.dto.req.AvailableCreateRequest;
+import com.postgraduate.domain.senior.domain.entity.Senior;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class Available {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long availableId;
+
+    @Column(nullable = false)
+    private String day;
+
+    @Column(nullable = false)
+    private String startTime;
+
+    @Column(nullable = false)
+    private String endTime;
+
+    @ManyToOne
+    private Senior senior;
+}

--- a/src/main/java/com/postgraduate/domain/available/domain/repository/AvailableRepository.java
+++ b/src/main/java/com/postgraduate/domain/available/domain/repository/AvailableRepository.java
@@ -1,0 +1,12 @@
+package com.postgraduate.domain.available.domain.repository;
+
+import com.postgraduate.domain.available.domain.entity.Available;
+import com.postgraduate.domain.senior.domain.entity.Senior;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AvailableRepository extends JpaRepository<Available, Long> {
+    List<Available> findAllBySenior(Senior senior);
+    void deleteAllBySenior(Senior senior);
+}

--- a/src/main/java/com/postgraduate/domain/available/domain/service/AvailableDeleteService.java
+++ b/src/main/java/com/postgraduate/domain/available/domain/service/AvailableDeleteService.java
@@ -1,0 +1,18 @@
+package com.postgraduate.domain.available.domain.service;
+
+import com.postgraduate.domain.available.application.dto.req.AvailableCreateRequest;
+import com.postgraduate.domain.available.domain.entity.Available;
+import com.postgraduate.domain.available.domain.repository.AvailableRepository;
+import com.postgraduate.domain.senior.domain.entity.Senior;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AvailableDeleteService {
+    private final AvailableRepository availableRepository;
+
+    public void delete(Senior senior) {
+        availableRepository.deleteAllBySenior(senior);
+    }
+}

--- a/src/main/java/com/postgraduate/domain/available/domain/service/AvailableGetService.java
+++ b/src/main/java/com/postgraduate/domain/available/domain/service/AvailableGetService.java
@@ -1,0 +1,20 @@
+package com.postgraduate.domain.available.domain.service;
+
+import com.postgraduate.domain.available.domain.entity.Available;
+import com.postgraduate.domain.available.domain.repository.AvailableRepository;
+import com.postgraduate.domain.senior.domain.entity.Senior;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AvailableGetService {
+    private final AvailableRepository availableRepository;
+
+    public List<Available> bySenior(Senior senior) {
+        List<Available> times = availableRepository.findAllBySenior(senior);
+        return times;
+    }
+}

--- a/src/main/java/com/postgraduate/domain/available/domain/service/AvailableSaveService.java
+++ b/src/main/java/com/postgraduate/domain/available/domain/service/AvailableSaveService.java
@@ -1,0 +1,16 @@
+package com.postgraduate.domain.available.domain.service;
+
+import com.postgraduate.domain.available.domain.entity.Available;
+import com.postgraduate.domain.available.domain.repository.AvailableRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AvailableSaveService {
+    private final AvailableRepository availableRepository;
+
+    public void save(Available available) {
+        availableRepository.save(available);
+    }
+}

--- a/src/main/java/com/postgraduate/domain/mentoring/application/mapper/MentoringMapper.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/mapper/MentoringMapper.java
@@ -26,7 +26,7 @@ public class MentoringMapper {
                 info.getMajor(),
                 info.getLab(),
                 mentoring.getDate(),
-                profile.getTerm(),
+                mentoring.getTerm(),
                 profile.getChatLink()
         );
     }
@@ -35,7 +35,6 @@ public class MentoringMapper {
         Senior senior = mentoring.getSenior();
         User user = senior.getUser();
         Info info = senior.getInfo();
-        Profile profile = senior.getProfile();
         return new DoneMentoringInfo(
                 mentoring.getMentoringId(),
                 senior.getSeniorId(),
@@ -45,7 +44,7 @@ public class MentoringMapper {
                 info.getMajor(),
                 info.getLab(),
                 mentoring.getDate(),
-                profile.getTerm()
+                mentoring.getTerm()
         );
     }
 
@@ -53,13 +52,12 @@ public class MentoringMapper {
         Senior senior = mentoring.getSenior();
         User user = senior.getUser();
         Info info = senior.getInfo();
-        Profile profile = senior.getProfile();
         return new WaitingMentoringInfo(
                 mentoring.getMentoringId(),
                 senior.getSeniorId(),
                 user.getProfile(), user.getNickName(),
                 info.getPostgradu(), info.getMajor(), info.getLab(),
-                profile.getTerm());
+                mentoring.getTerm());
     }
     public static AppliedMentoringDetailResponse mapToAppliedDetailInfo(Mentoring mentoring) {
         Senior senior = mentoring.getSenior();
@@ -89,29 +87,26 @@ public class MentoringMapper {
 
     public static WaitingSeniorMentoringInfo mapToSeniorWaitingInfo(Mentoring mentoring, long remainTime) {
         User user = mentoring.getUser();
-        Senior senior = mentoring.getSenior();
         return new WaitingSeniorMentoringInfo(
                 mentoring.getMentoringId(),
                 user.getProfile(), user.getNickName(),
-                senior.getProfile().getTerm(),
+                mentoring.getTerm(),
                 remainTime);
     }
 
     public static ExpectedSeniorMentoringInfo mapToSeniorExpectedInfo(Mentoring mentoring) {
         User user = mentoring.getUser();
-        Senior senior = mentoring.getSenior();
         return new ExpectedSeniorMentoringInfo(mentoring.getMentoringId(),
                 user.getProfile(), user.getNickName(),
-                senior.getProfile().getTerm(),
+                mentoring.getTerm(),
                 mentoring.getDate());
     }
 
     public static DoneSeniorMentoringInfo mapToSeniorDoneInfo(Mentoring mentoring, Salary salary) {
         User user = mentoring.getUser();
-        Senior senior = mentoring.getSenior();
         return new DoneSeniorMentoringInfo(mentoring.getMentoringId(),
                 user.getProfile(), user.getNickName(),
-                senior.getProfile().getTerm(),
+                mentoring.getTerm(),
                 mentoring.getDate(),
                 salary.getSalaryDate(), salary.getStatus());
     }
@@ -119,12 +114,11 @@ public class MentoringMapper {
     public static SeniorMentoringDetailResponse mapToSeniorMentoringDetail(Mentoring mentoring) {
         String[] dates = mentoring.getDate().split(",");
         User user = mentoring.getUser();
-        Senior senior = mentoring.getSenior();
         return new SeniorMentoringDetailResponse(
                 user.getProfile(), user.getNickName(),
                 mentoring.getTopic(), mentoring.getQuestion(),
                 dates,
-                senior.getProfile().getTerm()
+                mentoring.getTerm()
         );
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/entity/Mentoring.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/entity/Mentoring.java
@@ -40,6 +40,10 @@ public class Mentoring {
 
     @Column(nullable = false)
     @Builder.Default
+    private int term = 40;
+
+    @Column(nullable = false)
+    @Builder.Default
     private int pay = 20000;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/postgraduate/domain/salary/application/mapper/SalaryMapper.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/mapper/SalaryMapper.java
@@ -23,7 +23,7 @@ public class SalaryMapper {
                 user.getProfile(),
                 user.getNickName(),
                 mentoring.getDate(),
-                salary.getSenior().getProfile().getTerm(),
+                mentoring.getTerm(),
                 mentoring.getPay(),
                 salary.getSalaryDate()
         );

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/req/SeniorMyPageProfileRequest.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/req/SeniorMyPageProfileRequest.java
@@ -1,6 +1,9 @@
 package com.postgraduate.domain.senior.application.dto.req;
 
+import com.postgraduate.domain.available.application.dto.req.AvailableCreateRequest;
 import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
 
 public record SeniorMyPageProfileRequest(
         @NotNull
@@ -18,5 +21,5 @@ public record SeniorMyPageProfileRequest(
         @NotNull
         String oneLiner,
         @NotNull
-        String time
+        List<AvailableCreateRequest> times
 ) { }

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/req/SeniorProfileRequest.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/req/SeniorProfileRequest.java
@@ -1,6 +1,9 @@
 package com.postgraduate.domain.senior.application.dto.req;
 
+import com.postgraduate.domain.available.application.dto.req.AvailableCreateRequest;
 import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
 
 public record SeniorProfileRequest(
         @NotNull
@@ -10,8 +13,7 @@ public record SeniorProfileRequest(
         @NotNull
         String chatLink,
         @NotNull
-        String time,
+        String oneLiner,
         @NotNull
-        String oneLiner
-) {
-}
+        List<AvailableCreateRequest> times
+) {}

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorDetailResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorDetailResponse.java
@@ -9,6 +9,8 @@ public record SeniorDetailResponse(
         @NotNull
         String nickName,
         @NotNull
+        int term,
+        @NotNull
         String profile,
         @NotNull
         String postgradu,

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorDetailResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorDetailResponse.java
@@ -1,6 +1,9 @@
 package com.postgraduate.domain.senior.application.dto.res;
 
+import com.postgraduate.domain.available.application.dto.res.AvailableTimeResponse;
 import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
 
 public record SeniorDetailResponse(
         @NotNull
@@ -24,5 +27,5 @@ public record SeniorDetailResponse(
         @NotNull
         String target,
         @NotNull
-        String time
+        List<AvailableTimeResponse> times
 ) { }

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorMyPageProfileResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorMyPageProfileResponse.java
@@ -1,7 +1,10 @@
 package com.postgraduate.domain.senior.application.dto.res;
 
 
+import com.postgraduate.domain.available.application.dto.res.AvailableTimeResponse;
 import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
 
 public record SeniorMyPageProfileResponse(
         @NotNull
@@ -19,5 +22,5 @@ public record SeniorMyPageProfileResponse(
         @NotNull
         String oneLiner,
         @NotNull
-        String time
+        List<AvailableTimeResponse> times
 ) { }

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorSearchResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorSearchResponse.java
@@ -16,7 +16,5 @@ public record SeniorSearchResponse(
         @NotNull
         String lab,
         @NotNull
-        String oneLiner,
-        @NotNull
         String[] keyword
 ) {}

--- a/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
@@ -3,6 +3,7 @@ package com.postgraduate.domain.senior.application.mapper;
 import com.postgraduate.domain.account.domain.entity.Account;
 import com.postgraduate.domain.auth.application.dto.req.SeniorChangeRequest;
 import com.postgraduate.domain.auth.application.dto.req.SeniorSignUpRequest;
+import com.postgraduate.domain.available.application.dto.res.AvailableTimeResponse;
 import com.postgraduate.domain.senior.application.dto.req.SeniorMyPageProfileRequest;
 import com.postgraduate.domain.senior.application.dto.req.SeniorProfileRequest;
 import com.postgraduate.domain.senior.application.dto.res.*;
@@ -16,6 +17,7 @@ import com.postgraduate.domain.user.domain.entity.User;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
 public class SeniorMapper {
 
@@ -62,7 +64,6 @@ public class SeniorMapper {
                 .chatLink(profileRequest.chatLink())
                 .oneLiner(profileRequest.oneLiner())
                 .target(profileRequest.target())
-                .time(profileRequest.time())
                 .build();
     }
 
@@ -72,7 +73,6 @@ public class SeniorMapper {
                 .chatLink(profileRequest.chatLink())
                 .oneLiner(profileRequest.oneLiner())
                 .target(profileRequest.target())
-                .time(profileRequest.time())
                 .build();
     }
 
@@ -117,7 +117,7 @@ public class SeniorMapper {
         return new SeniorMyPageResponse(senior.getSeniorId(), user.getNickName(), user.getProfile(), certificationRegister, profileRegister);
     }
 
-    public static SeniorMyPageProfileResponse mapToMyPageProfile(Senior senior) {
+    public static SeniorMyPageProfileResponse mapToMyPageProfile(Senior senior, List<AvailableTimeResponse> times) {
         Info info = senior.getInfo();
         Profile profile = senior.getProfile();
         String[] keyword = info.getKeyword().split(",");
@@ -130,7 +130,7 @@ public class SeniorMapper {
                 profile.getChatLink(),
                 field,
                 profile.getOneLiner(),
-                profile.getTime()
+                times
         );
     }
 
@@ -153,7 +153,7 @@ public class SeniorMapper {
                 user.getNickName());
     }
 
-    public static SeniorDetailResponse mapToSeniorDetail(Senior senior) {
+    public static SeniorDetailResponse mapToSeniorDetail(Senior senior, List<AvailableTimeResponse> times) {
         Info info = senior.getInfo();
         Profile profile = senior.getProfile();
         String[] keyword = info.getKeyword().split(",");
@@ -168,7 +168,7 @@ public class SeniorMapper {
                 profile.getInfo(),
                 profile.getOneLiner(),
                 profile.getTarget(),
-                profile.getTime()
+                times
         );
     }
 

--- a/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
@@ -159,6 +159,7 @@ public class SeniorMapper {
         String[] keyword = info.getKeyword().split(",");
         return new SeniorDetailResponse(
                 senior.getUser().getNickName(),
+                profile.getTerm(),
                 senior.getUser().getProfile(),
                 info.getPostgradu(),
                 info.getMajor(),
@@ -175,20 +176,12 @@ public class SeniorMapper {
     public static SeniorSearchResponse mapToSeniorSearch(Senior senior) {
         User user = senior.getUser();
         Info info = senior.getInfo();
-        Profile profile = senior.getProfile();
         String[] allKeywords = info.getKeyword().split(",");
         String[] keyword = Arrays.copyOf(allKeywords, Math.min(3, allKeywords.length));
 
         return new SeniorSearchResponse(senior.getSeniorId(), user.getProfile(), user.getNickName(),
                 info.getPostgradu(), info.getMajor(), info.getLab(),
-                profile.getOneLiner(), keyword);
-    }
-
-    public static SeniorFieldResponse mapToSeniorField(Senior senior) {
-        User user = senior.getUser();
-        Info info = senior.getInfo();
-        return new SeniorFieldResponse(senior.getSeniorId(), user.getProfile(), user.getNickName(),
-                info.getPostgradu(), info.getMajor(), info.getLab());
+                keyword);
     }
 
     public static SeniorProfileResponse mapToSeniorProfile(Senior senior) {

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
@@ -1,5 +1,9 @@
 package com.postgraduate.domain.senior.application.usecase;
 
+import com.postgraduate.domain.available.application.dto.res.AvailableTimeResponse;
+import com.postgraduate.domain.available.application.mapper.AvailableMapper;
+import com.postgraduate.domain.available.domain.entity.Available;
+import com.postgraduate.domain.available.domain.service.AvailableGetService;
 import com.postgraduate.domain.senior.application.dto.res.*;
 import com.postgraduate.domain.senior.application.mapper.SeniorMapper;
 import com.postgraduate.domain.senior.domain.entity.Senior;
@@ -20,11 +24,16 @@ import static com.postgraduate.domain.senior.application.mapper.SeniorMapper.*;
 public class SeniorInfoUseCase {
     private final SeniorGetService seniorGetService;
     private final SeniorUpdateService seniorUpdateService;
+    private final AvailableGetService availableGetService;
 
     public SeniorDetailResponse getSeniorDetail(Long seniorId) {
         Senior senior = seniorGetService.bySeniorIdWithCertification(seniorId);
         seniorUpdateService.updateHit(senior);
-        return mapToSeniorDetail(senior);
+        List<Available> availables = availableGetService.bySenior(senior);
+        List<AvailableTimeResponse> times = availables.stream()
+                .map(AvailableMapper::mapToAvailableTimes)
+                .toList();
+        return mapToSeniorDetail(senior, times);
     }
 
     public AllSeniorSearchResponse getSearchSenior(String search, Integer page, String sort) {

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
@@ -1,6 +1,7 @@
 package com.postgraduate.domain.senior.application.usecase;
 
 import com.postgraduate.domain.available.application.dto.res.AvailableTimeResponse;
+import com.postgraduate.domain.available.application.dto.res.AvailableTimesResponse;
 import com.postgraduate.domain.available.application.mapper.AvailableMapper;
 import com.postgraduate.domain.available.domain.entity.Available;
 import com.postgraduate.domain.available.domain.service.AvailableGetService;
@@ -56,5 +57,14 @@ public class SeniorInfoUseCase {
         Senior senior = seniorGetService.bySeniorId(seniorId);
         SeniorProfileResponse seniorProfileResponse = mapToSeniorProfile(senior);
         return seniorProfileResponse;
+    }
+
+    public AvailableTimesResponse getSeniorTimes(Long seniorId) {
+        Senior senior = seniorGetService.bySeniorId(seniorId);
+        List<Available> availables = availableGetService.bySenior(senior);
+        List<AvailableTimeResponse> times = availables.stream()
+                .map(AvailableMapper::mapToAvailableTimes)
+                .toList();
+        return new AvailableTimesResponse(times);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
@@ -4,6 +4,11 @@ import com.postgraduate.domain.account.domain.entity.Account;
 import com.postgraduate.domain.account.domain.service.AccountGetService;
 import com.postgraduate.domain.account.domain.service.AccountSaveService;
 import com.postgraduate.domain.account.domain.service.AccountUpdateService;
+import com.postgraduate.domain.available.application.dto.req.AvailableCreateRequest;
+import com.postgraduate.domain.available.application.mapper.AvailableMapper;
+import com.postgraduate.domain.available.domain.entity.Available;
+import com.postgraduate.domain.available.domain.service.AvailableSaveService;
+import com.postgraduate.domain.available.domain.service.AvailableDeleteService;
 import com.postgraduate.domain.senior.application.dto.req.*;
 import com.postgraduate.domain.senior.domain.entity.Profile;
 import com.postgraduate.domain.senior.domain.entity.Senior;
@@ -16,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.postgraduate.domain.account.application.mapper.AccountMapper.mapToAccount;
@@ -28,6 +34,8 @@ public class SeniorManageUseCase {
     private final UserUpdateService userUpdateService;
     private final SeniorUpdateService seniorUpdateService;
     private final SeniorGetService seniorGetService;
+    private final AvailableSaveService availableSaveService;
+    private final AvailableDeleteService availableDeleteService;
     private final AccountGetService accountGetService;
     private final AccountSaveService accountSaveService;
     private final AccountUpdateService accountUpdateService;
@@ -42,6 +50,11 @@ public class SeniorManageUseCase {
         Senior senior = seniorGetService.byUser(user);
         Profile profile = mapToProfile(profileRequest);
         seniorUpdateService.signUpSeniorProfile(senior, profile);
+        List<AvailableCreateRequest> availableCreateRequests = profileRequest.times();
+        availableCreateRequests.forEach(createRequest -> {
+            Available available = AvailableMapper.mapToAvailable(senior, createRequest);
+            availableSaveService.save(available);
+        });
     }
 
     public void saveAccount(User user, SeniorAccountRequest accountRequest) {
@@ -54,6 +67,12 @@ public class SeniorManageUseCase {
         Senior senior = seniorGetService.byUser(user);
         Profile profile = mapToProfile(myPageProfileRequest);
         seniorUpdateService.updateMyPageProfile(senior, myPageProfileRequest, profile);
+        availableDeleteService.delete(senior);
+        List<AvailableCreateRequest> availableCreateRequests = myPageProfileRequest.times();
+        availableCreateRequests.forEach(createRequest -> {
+            Available available = AvailableMapper.mapToAvailable(senior, createRequest);
+            availableSaveService.save(available);
+        });
     }
 
     public void updateSeniorMyPageUserAccount(User user, SeniorMyPageUserAccountRequest myPageUserAccountRequest) {

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
@@ -2,6 +2,10 @@ package com.postgraduate.domain.senior.application.usecase;
 
 import com.postgraduate.domain.account.domain.entity.Account;
 import com.postgraduate.domain.account.domain.service.AccountGetService;
+import com.postgraduate.domain.available.application.dto.res.AvailableTimeResponse;
+import com.postgraduate.domain.available.application.mapper.AvailableMapper;
+import com.postgraduate.domain.available.domain.entity.Available;
+import com.postgraduate.domain.available.domain.service.AvailableGetService;
 import com.postgraduate.domain.senior.application.dto.res.SeniorMyPageProfileResponse;
 import com.postgraduate.domain.senior.application.dto.res.SeniorMyPageResponse;
 import com.postgraduate.domain.senior.application.dto.res.SeniorMyPageUserAccountResponse;
@@ -9,14 +13,13 @@ import com.postgraduate.domain.senior.domain.entity.Profile;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.entity.constant.Status;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
-import com.postgraduate.domain.senior.exception.NoneAccountException;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.global.config.security.util.EncryptorUtils;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.postgraduate.domain.senior.application.mapper.SeniorMapper.*;
@@ -27,6 +30,7 @@ import static java.util.Optional.ofNullable;
 @Transactional
 public class SeniorMyPageUseCase {
     private final SeniorGetService seniorGetService;
+    private final AvailableGetService availableGetService;
     private final AccountGetService accountGetService;
     private final EncryptorUtils encryptorUtils;
 
@@ -39,7 +43,11 @@ public class SeniorMyPageUseCase {
 
     public SeniorMyPageProfileResponse getSeniorMyPageProfile(User user) {
         Senior senior = seniorGetService.byUser(user);
-        return mapToMyPageProfile(senior);
+        List<Available> availables = availableGetService.bySenior(senior);
+        List<AvailableTimeResponse> times = availables.stream()
+                .map(AvailableMapper::mapToAvailableTimes)
+                .toList();
+        return mapToMyPageProfile(senior, times);
     }
 
     public SeniorMyPageUserAccountResponse getSeniorMyPageUserAccount(User user) {

--- a/src/main/java/com/postgraduate/domain/senior/domain/entity/Profile.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/entity/Profile.java
@@ -21,8 +21,6 @@ public class Profile {
 
     private String chatLink;
 
-    private String time;
-
     @Builder.Default
     private Integer term = 40;
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -1,5 +1,6 @@
 package com.postgraduate.domain.senior.presentation;
 
+import com.postgraduate.domain.available.application.dto.res.AvailableTimesResponse;
 import com.postgraduate.domain.senior.application.dto.req.*;
 import com.postgraduate.domain.senior.application.dto.res.*;
 import com.postgraduate.domain.senior.application.usecase.SeniorInfoUseCase;
@@ -100,6 +101,13 @@ public class SeniorController {
     public ResponseDto<SeniorProfileResponse> getSeniorProfile(@PathVariable Long seniorId) {
         SeniorProfileResponse seniorProfile = seniorInfoUseCase.getSeniorProfile(seniorId);
         return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_INFO.getMessage(), seniorProfile);
+    }
+
+    @GetMapping("/{seniorId}/times")
+    @Operation(summary = "대학원생 가능 시간 확인", description = "신청서 작성에서 가능 시간 작성시 노출 필요")
+    public ResponseDto<AvailableTimesResponse> getSeniorTimes(@PathVariable Long seniorId) {
+        AvailableTimesResponse times = seniorInfoUseCase.getSeniorTimes(seniorId);
+        return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_TIME.getMessage(), times);
     }
 
     @GetMapping("/search")

--- a/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseMessage.java
@@ -13,6 +13,7 @@ public enum SeniorResponseMessage {
     UPDATE_MYPAGE_PROFILE("대학원생 마이페이지 프로필 수정에 성공하였습니다"),
     UPDATE_MYPAGE_ACCOOUNT("대학원생 마이페이지 계정 수정에 성공하였습니다"),
     GET_SENIOR_INFO("대학원생 정보 조회에 성공하였습니다"),
+    GET_SENIOR_TIME("대학원생 가능 시간 조회에 성공하였습니다"),
     GET_SENIOR_MYPAGE_PROFILE("대학원생 마이페이지 프로필 조회에 성공하였습니다"),
     GET_SENIOR_MYPAGE_ACCOUNT("대학원생 마이페이지 계정 조회에 성공하였습니다"),
     GET_SENIOR_PROFILE("대학원생 프로필 조회에 성공하였습니다"),


### PR DESCRIPTION
## 🦝 PR 요약
기존 대학원생 가능 시간 로직 수정 -> 기획 수정에 따라서

## ✨ PR 상세 내용
- 대학원생 가능 시간에 대해 요일, 시작시간, 마감시간 가지는 테이블 생성
기존의 text로 받는 형식 삭제
- 위의 결과에 따라 기존의 시간 응답을 요일, 시작시간, 마감시간 정보를 가지는 리스트로 반환하도록 변환
- 기존의 멘토링에서 선배의 term을 가져와서 사용하고 있던 부분 mentoring자체의 term을 가지도록 수정
- 검색 결과 한줄 소개 삭제

## 🚨 주의 사항
멘토링의 경우 초기의 배포에서는 40분 고정이라 하였지만, 이후에는 멘토링마다 달라질 수 있는 점,
선배가 1시간 30분 가능하다고 멘토링이 무조건 1시간 30분이 되는 것은 아니기에 멘토링 자체의 term을 가지도록 생성
- 우선은 40분을 기본으로 가지도록 생성

## ✅ 체크 리스트
- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
