### PR TITLE
RAC-242 fix : 선배 계정 설정시 계좌 포함 필수 유동적으로 수정

### DIFF
--- a/src/main/java/com/postgraduate/domain/senior/application/dto/req/SeniorMyPageUserAccountRequest.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/req/SeniorMyPageUserAccountRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.NotNull;
 public record SeniorMyPageUserAccountRequest(
         @NotNull String nickName,
         @NotNull String phoneNumber,
-        @NotNull String accountNumber,
-        @NotNull String bank,
-        @NotNull String accountHolder,
-        @NotNull String profile
+        @NotNull String profile,
+        String accountNumber,
+        String bank,
+        String accountHolder
 ) {}

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
@@ -13,6 +13,7 @@ import com.postgraduate.domain.senior.domain.entity.Profile;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
 import com.postgraduate.domain.senior.domain.service.SeniorUpdateService;
+import com.postgraduate.domain.senior.exception.NoneAccountException;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.service.UserUpdateService;
 import com.postgraduate.global.config.security.util.EncryptorUtils;
@@ -78,6 +79,8 @@ public class SeniorManageUseCase {
             updateSeniorMyPageUserAccountNoneAccount(senior, user, myPageUserAccountRequest);
             return;
         }
+        if (myPageUserAccountRequest.accountNumber().isEmpty() || myPageUserAccountRequest.accountHolder().isEmpty() || myPageUserAccountRequest.bank().isEmpty())
+            throw new NoneAccountException();
         Account account = optionalAccount.get();
         String accountNumber = encryptorUtils.encryptData(myPageUserAccountRequest.accountNumber());
         userUpdateService.updateSeniorUserAccount(user.getUserId(), myPageUserAccountRequest);
@@ -85,6 +88,10 @@ public class SeniorManageUseCase {
     }
 
     private void updateSeniorMyPageUserAccountNoneAccount(Senior senior, User user, SeniorMyPageUserAccountRequest myPageUserAccountRequest) {
+        if (myPageUserAccountRequest.accountNumber().isEmpty() || myPageUserAccountRequest.accountHolder().isEmpty() || myPageUserAccountRequest.bank().isEmpty()) {
+            userUpdateService.updateSeniorUserAccount(user.getUserId(), myPageUserAccountRequest);
+            return;
+        }
         String accountNumber = encryptorUtils.encryptData(myPageUserAccountRequest.accountNumber());
         Account account = mapToAccount(senior, myPageUserAccountRequest, accountNumber);
         userUpdateService.updateSeniorUserAccount(user.getUserId(), myPageUserAccountRequest);

--- a/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseMessage.java
@@ -22,7 +22,7 @@ public enum SeniorResponseMessage {
     UPDATE_STATUS("대학원생 승인 요청 응답에 성공하였습니다"),
 
     NONE_SENIOR("등록된 멘토가 없습니다."),
-    NONE_ACCOUNT("등록된 계좌가 없습니다."),
+    NONE_ACCOUNT("계좌가 없습니다."),
     NOT_WAITING_STATUS("승인대기 상태의 선배가 아닙니다.");
 
     private final String message;


### PR DESCRIPTION
## 🦝 PR 요약
계좌 포함 필수 아니도록 수정

## ✨ PR 상세 내용
- SeniorMyPageUserAccountRequest 계좌 관련 NotNull 제거
- 기존에 계좌 존재하지만 빈값 보낼 경우 예외 발생
- 기존에 계좌 존재하지 않을 경우 빈값 허용

## 🚨 주의 사항
로직에 문제 없는지 확인해주세요

## ✅ 체크 리스트
- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
