### PR TITLE
RAC-248 feat : 선배가 후배로 변경하는 경우 로직 추가 및 기존 로직 변경

### DIFF
--- a/src/main/java/com/postgraduate/domain/auth/application/dto/req/UserChangeRequest.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/dto/req/UserChangeRequest.java
@@ -1,0 +1,9 @@
+package com.postgraduate.domain.auth.application.dto.req;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UserChangeRequest(String major,
+                                String field,
+                                @NotNull
+                                Boolean matchingReceive) {
+}

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/jwt/JwtUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/jwt/JwtUseCase.java
@@ -25,8 +25,7 @@ public class JwtUseCase {
     private int accessExpiration;
 
     public JwtTokenResponse signIn(User user) {
-        if (user.getIsDelete())
-            throw new DeletedUserException();
+        checkDelete(user);
         if (user.getRole() == SENIOR)
             return seniorToken(user);
         if (user.getRole() == ADMIN)
@@ -48,14 +47,12 @@ public class JwtUseCase {
     }
 
     public JwtTokenResponse changeUser(User user) {
-        if (user.getIsDelete())
-            throw new DeletedUserException();
+        checkDelete(user);
         return userToken(user);
     }
 
     public JwtTokenResponse changeSenior(User user) {
-        if (user.getIsDelete())
-            throw new DeletedUserException();
+        checkDelete(user);
         return seniorToken(user);
     }
 
@@ -66,8 +63,7 @@ public class JwtUseCase {
     }
 
     private JwtTokenResponse seniorToken(User user) {
-        if (user.getIsDelete())
-            throw new DeletedUserException();
+        checkDelete(user);
         return generateToken(user, SENIOR);
     }
 
@@ -79,5 +75,10 @@ public class JwtUseCase {
         String accessToken = jwtUtils.generateAccessToken(user.getUserId(), role);
         String refreshToken = jwtUtils.generateRefreshToken(user.getUserId(), role);
         return new JwtTokenResponse(accessToken, accessExpiration, refreshToken, refreshExpiration, role);
+    }
+
+    private void checkDelete(User user) {
+        if (user.getIsDelete())
+            throw new DeletedUserException();
     }
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
@@ -3,6 +3,7 @@ package com.postgraduate.domain.auth.application.usecase.oauth;
 import com.postgraduate.domain.auth.application.dto.req.SeniorChangeRequest;
 import com.postgraduate.domain.auth.application.dto.req.SeniorSignUpRequest;
 import com.postgraduate.domain.auth.application.dto.req.SignUpRequest;
+import com.postgraduate.domain.auth.application.dto.req.UserChangeRequest;
 import com.postgraduate.domain.senior.application.mapper.SeniorMapper;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorSaveService;
@@ -45,11 +46,15 @@ public class SignUpUseCase {
         return senior.getUser();
     }
 
-
     public User changeSenior(User user, SeniorChangeRequest changeRequest) {
         Senior senior = SeniorMapper.mapToSenior(user, changeRequest); //todo : 예외 처리
         seniorSaveService.saveSenior(senior);
         userUpdateService.updateRole(user.getUserId(), Role.SENIOR);
         return userGetService.getUser(user.getUserId());
+    }
+
+    public void changeUser(User user, UserChangeRequest changeRequest) {
+        Wish wish = WishMapper.mapToWish(user, changeRequest);
+        wishSaveService.saveWish(wish);
     }
 }

--- a/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
@@ -1,9 +1,6 @@
 package com.postgraduate.domain.auth.presentation;
 
-import com.postgraduate.domain.auth.application.dto.req.CodeRequest;
-import com.postgraduate.domain.auth.application.dto.req.SeniorChangeRequest;
-import com.postgraduate.domain.auth.application.dto.req.SeniorSignUpRequest;
-import com.postgraduate.domain.auth.application.dto.req.SignUpRequest;
+import com.postgraduate.domain.auth.application.dto.req.*;
 import com.postgraduate.domain.auth.application.dto.res.AuthUserResponse;
 import com.postgraduate.domain.auth.application.dto.res.JwtTokenResponse;
 import com.postgraduate.domain.auth.application.usecase.oauth.SelectOauth;
@@ -74,6 +71,22 @@ public class AuthController {
         return ResponseDto.create(AUTH_CREATE.getCode(), SUCCESS_AUTH.getMessage(), jwtToken);
     }
 
+    @PostMapping("/user/token")
+    @Operation(summary = "후배로 변경 | 토큰 필요", description = "후배로 변경 가능한 경우 후배 토큰 발급")
+    public ResponseDto<JwtTokenResponse> changeUserToken(@AuthenticationPrincipal User user) {
+        JwtTokenResponse jwtToken = jwtUseCase.changeUser(user);
+        return ResponseDto.create(AUTH_CREATE.getCode(), SUCCESS_AUTH.getMessage(), jwtToken);
+    }
+
+    @PostMapping("/user/change")
+    @Operation(summary = "후배로 추가 가입 | 토큰 필요", description = "대학원생 대학생으로 변경 추가 가입")
+    public ResponseDto<JwtTokenResponse> changeUser(@AuthenticationPrincipal User user,
+                                                    @RequestBody @Valid UserChangeRequest changeRequest) {
+        signUpUseCase.changeUser(user, changeRequest);
+        JwtTokenResponse jwtToken = jwtUseCase.changeUser(user);
+        return ResponseDto.create(AUTH_CREATE.getCode(), SUCCESS_AUTH.getMessage(), jwtToken);
+    }
+
     @PostMapping("/senior/signup")
     @Operation(summary = "대학원생 가입 - 필수 과정만", description = "대학원생 회원가입 - 필수 과정만")
     public ResponseDto<JwtTokenResponse> singUpSenior(@RequestBody @Valid SeniorSignUpRequest request) {
@@ -83,14 +96,20 @@ public class AuthController {
     }
 
     @PostMapping("/senior/change")
-    @Operation(summary = "선배로 업데이트 | 토큰 필요", description = "대학생 대학원생으로 변경")
+    @Operation(summary = "선배로 추가 가입 | 토큰 필요", description = "대학생 대학원생으로 변경 추가 가입")
     public ResponseDto<JwtTokenResponse> changeSenior(@AuthenticationPrincipal User user,
                                                       @RequestBody @Valid SeniorChangeRequest changeRequest) {
         User changeUser = signUpUseCase.changeSenior(user, changeRequest);
-        JwtTokenResponse jwtToken = jwtUseCase.signIn(changeUser);
+        JwtTokenResponse jwtToken = jwtUseCase.changeSenior(changeUser);
         return ResponseDto.create(SENIOR_CREATE.getCode(), CREATE_SENIOR.getMessage(), jwtToken);
     }
 
+    @PostMapping("/senior/token")
+    @Operation(summary = "선배로 변경 | 토큰 필요", description = "선배로 변경 가능한 경우 선배 토큰 발급")
+    public ResponseDto<JwtTokenResponse> changeSeniorToken(@AuthenticationPrincipal User user) {
+        JwtTokenResponse jwtToken = jwtUseCase.changeSenior(user);
+        return ResponseDto.create(AUTH_CREATE.getCode(), SUCCESS_AUTH.getMessage(), jwtToken);
+    }
 
     @PostMapping("/refresh")
     @Operation(summary = "토큰 재발급 | 토큰 필요", description = "refreshToken 으로 토큰 재발급")

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorPossibleResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorPossibleResponse.java
@@ -1,0 +1,5 @@
+package com.postgraduate.domain.senior.application.dto.res;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SeniorPossibleResponse(@NotNull Boolean possible) {}

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseCase.java
@@ -9,11 +9,14 @@ import com.postgraduate.domain.available.domain.service.AvailableGetService;
 import com.postgraduate.domain.senior.application.dto.res.SeniorMyPageProfileResponse;
 import com.postgraduate.domain.senior.application.dto.res.SeniorMyPageResponse;
 import com.postgraduate.domain.senior.application.dto.res.SeniorMyPageUserAccountResponse;
+import com.postgraduate.domain.senior.application.dto.res.SeniorPossibleResponse;
 import com.postgraduate.domain.senior.domain.entity.Profile;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.entity.constant.Status;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
 import com.postgraduate.domain.user.domain.entity.User;
+import com.postgraduate.domain.wish.domain.entity.Wish;
+import com.postgraduate.domain.wish.domain.service.WishGetService;
 import com.postgraduate.global.config.security.util.EncryptorUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +26,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.postgraduate.domain.senior.application.mapper.SeniorMapper.*;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static java.util.Optional.ofNullable;
 
 @Service
@@ -33,6 +38,7 @@ public class SeniorMyPageUseCase {
     private final AvailableGetService availableGetService;
     private final AccountGetService accountGetService;
     private final EncryptorUtils encryptorUtils;
+    private final WishGetService wishGetService;
 
     public SeniorMyPageResponse getSeniorInfo(User user) {
         Senior senior = seniorGetService.byUser(user);
@@ -58,5 +64,12 @@ public class SeniorMyPageUseCase {
         Account account = optionalAccount.get();
         String accountNumber = encryptorUtils.decryptData(account.getAccountNumber());
         return mapToMyPageUserAccount(senior, account, accountNumber);
+    }
+
+    public SeniorPossibleResponse checkUser(User user) {
+        Optional<Wish> wish = wishGetService.byUser(user);
+        if (wish.isEmpty())
+            return new SeniorPossibleResponse(FALSE);
+        return new SeniorPossibleResponse(TRUE);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -127,4 +127,11 @@ public class SeniorController {
         AllSeniorSearchResponse searchSenior = seniorInfoUseCase.getFieldSenior(field, postgradu, page);
         return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_LIST_INFO.getMessage(), searchSenior);
     }
+
+    @GetMapping("/me/role")
+    @Operation(summary = "후배 전환시 가능 여부 확인 | 토큰 필요", description = "true-가능, false-불가능")
+    public ResponseDto<SeniorPossibleResponse> checkRole(@AuthenticationPrincipal User user) {
+        SeniorPossibleResponse possibleResponse = seniorMyPageUseCase.checkUser(user);
+        return ResponseDto.create(SENIOR_FIND.getCode(), GET_USER_CHECK.getMessage(), possibleResponse);
+    }
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseMessage.java
@@ -20,6 +20,7 @@ public enum SeniorResponseMessage {
     GET_SENIOR_LIST_INFO("대학원생 리스트 조회에 성공하였습니다."),
     UPDATE_CERTIFICATION("대학원생 인증사진 업로드에 성공하였습니다"),
     UPDATE_STATUS("대학원생 승인 요청 응답에 성공하였습니다"),
+    GET_USER_CHECK("후배 변경 가능 여부 확인에 성공하였습니다"),
 
     NONE_SENIOR("등록된 멘토가 없습니다."),
     NONE_ACCOUNT("계좌가 없습니다."),

--- a/src/main/java/com/postgraduate/domain/wish/application/mapper/WishMapper.java
+++ b/src/main/java/com/postgraduate/domain/wish/application/mapper/WishMapper.java
@@ -1,11 +1,21 @@
 package com.postgraduate.domain.wish.application.mapper;
 
 import com.postgraduate.domain.auth.application.dto.req.SignUpRequest;
+import com.postgraduate.domain.auth.application.dto.req.UserChangeRequest;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.wish.domain.entity.Wish;
 
 public class WishMapper {
     public static Wish mapToWish(User user, SignUpRequest request) {
+        return Wish.builder()
+                .user(user)
+                .major(request.major())
+                .field(request.field())
+                .matchingReceive(request.matchingReceive())
+                .build();
+    }
+
+    public static Wish mapToWish(User user, UserChangeRequest request) {
         return Wish.builder()
                 .user(user)
                 .major(request.major())

--- a/src/main/java/com/postgraduate/global/config/security/jwt/util/JwtUtils.java
+++ b/src/main/java/com/postgraduate/global/config/security/jwt/util/JwtUtils.java
@@ -84,12 +84,14 @@ public class JwtUtils {
         return refreshToken;
     }
 
-    public void checkRedis(Long id, HttpServletRequest request) {
+    public String checkRedis(Long id, HttpServletRequest request) {
         String refreshToken = request.getHeader(AUTHORIZATION).split(" ")[1];
         String redisToken = redisRepository.getValues(REFRESH.toString() + id)
                 .orElseThrow(NoneRefreshTokenException::new);
         if (!redisToken.equals(refreshToken))
             throw new InvalidRefreshTokenException();
+        Claims claims = parseClaims(refreshToken);
+        return claims.get(ROLE).toString();
     }
 
     public void makeExpired(Long id) {

--- a/src/test/java/com/postgraduate/domain/auth/application/usecase/jwt/JwtUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/auth/application/usecase/jwt/JwtUseCaseTest.java
@@ -3,6 +3,8 @@ package com.postgraduate.domain.auth.application.usecase.jwt;
 import com.postgraduate.domain.auth.application.dto.res.JwtTokenResponse;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.exception.DeletedUserException;
+import com.postgraduate.domain.wish.domain.entity.Wish;
+import com.postgraduate.domain.wish.domain.service.WishGetService;
 import com.postgraduate.global.config.security.jwt.exception.InvalidRefreshTokenException;
 import com.postgraduate.global.config.security.jwt.exception.NoneRefreshTokenException;
 import com.postgraduate.global.config.security.jwt.util.JwtUtils;
@@ -14,6 +16,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Optional;
 
 import static com.postgraduate.domain.user.domain.entity.constant.Role.SENIOR;
 import static com.postgraduate.domain.user.domain.entity.constant.Role.USER;
@@ -29,6 +33,8 @@ import static org.mockito.BDDMockito.*;
 public class JwtUseCaseTest {
     @Mock
     private JwtUtils jwtUtils;
+    @Mock
+    private WishGetService wishGetService;
     @InjectMocks
     private JwtUseCase jwtUseCase;
 
@@ -48,6 +54,8 @@ public class JwtUseCaseTest {
                 .willReturn("accessToken");
         given(jwtUtils.generateRefreshToken(user.getUserId(), user.getRole()))
                 .willReturn("refreshToken");
+        given(wishGetService.byUser(user))
+                .willReturn(Optional.of(mock(Wish.class)));
 
         JwtTokenResponse jwtTokenResponse = jwtUseCase.signIn(user);
 
@@ -119,6 +127,10 @@ public class JwtUseCaseTest {
                 .willReturn("accessToken");
         given(jwtUtils.generateRefreshToken(user.getUserId(), user.getRole()))
                 .willReturn("refreshToken");
+        given(wishGetService.byUser(user))
+                .willReturn(Optional.of(mock(Wish.class)));
+        given(jwtUtils.checkRedis(user.getUserId(), request))
+                .willReturn(USER.toString());
 
         JwtTokenResponse jwtTokenResponse = jwtUseCase.regenerateToken(user, request);
 


### PR DESCRIPTION
## 🦝 PR 요약
선후배 변경시 로직 변경

## ✨ PR 상세 내용
선배에서 후배 변경하는 경우에도 가능한지 확인
- 가능할 경우 후배로 변경 토큰 요청
- 불가능할 경우 후배 정보 추가 기입 및 토큰 발급
후배에서 선배로 변경하는 경우 로직 수정
- 가능할 경우 선배로 변경 토큰 요청
- 불가능할 경우 선배 정보 추가 기입 및 토큰 발급

## 🚨 주의 사항
각각의 API 분리 및 RefreshToken 로직 수정
- 토큰 재발급의 기본 로직은 user.getRole()을 통해 권한을 넣어주는데, 그렇게 할 경우 후배로 변경된 상태의 선배가 SENIOR로 들어가기 때문에 현재의 ROLE에 맞추도록 수정

## ✅ 체크 리스트
- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
