### PR TITLE
RAC-249 feat: 매칭 기능

### DIFF
--- a/src/main/java/com/postgraduate/domain/admin/application/dto/UserInfo.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/dto/UserInfo.java
@@ -1,5 +1,6 @@
 package com.postgraduate.domain.admin.application.dto;
 
+import com.postgraduate.domain.wish.domain.entity.constant.Status;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
@@ -20,7 +21,7 @@ public record UserInfo(
         @NotNull
         Long wishId,
         @NotNull
-        Boolean wishStatus,
+        Status matchingStatus,
         @NotNull
         Boolean isSenior
 ) { }

--- a/src/main/java/com/postgraduate/domain/admin/application/dto/UserInfo.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/dto/UserInfo.java
@@ -20,5 +20,7 @@ public record UserInfo(
         @NotNull
         Long wishId,
         @NotNull
+        Boolean wishStatus,
+        @NotNull
         Boolean isSenior
 ) { }

--- a/src/main/java/com/postgraduate/domain/admin/application/mapper/AdminMapper.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/mapper/AdminMapper.java
@@ -37,6 +37,7 @@ public class AdminMapper {
     public static UserInfo mapToUserInfo(Wish wish) {
         User user = wish.getUser();
         Boolean isSenior = user.getRole() == Role.SENIOR;
+        Boolean wishStatus = wish.getMatchingReceive() ? wish.getStatus() : null;
         return new UserInfo(
                 user.getUserId(),
                 user.getNickName(),
@@ -45,6 +46,7 @@ public class AdminMapper {
                 user.getMarketingReceive(),
                 wish.getMatchingReceive(),
                 wish.getWishId(),
+                wishStatus,
                 isSenior
         );
     }

--- a/src/main/java/com/postgraduate/domain/admin/application/mapper/AdminMapper.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/mapper/AdminMapper.java
@@ -37,7 +37,6 @@ public class AdminMapper {
     public static UserInfo mapToUserInfo(Wish wish) {
         User user = wish.getUser();
         Boolean isSenior = user.getRole() == Role.SENIOR;
-        Boolean wishStatus = wish.getMatchingReceive() ? wish.getStatus() : null;
         return new UserInfo(
                 user.getUserId(),
                 user.getNickName(),
@@ -46,7 +45,7 @@ public class AdminMapper {
                 user.getMarketingReceive(),
                 wish.getMatchingReceive(),
                 wish.getWishId(),
-                wishStatus,
+                wish.getStatus(),
                 isSenior
         );
     }

--- a/src/main/java/com/postgraduate/domain/admin/application/usecase/UserManageByAdminUseCase.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/usecase/UserManageByAdminUseCase.java
@@ -6,6 +6,8 @@ import com.postgraduate.domain.admin.application.mapper.AdminMapper;
 import com.postgraduate.domain.wish.application.mapper.dto.res.WishResponse;
 import com.postgraduate.domain.wish.domain.entity.Wish;
 import com.postgraduate.domain.wish.domain.service.WishGetService;
+import com.postgraduate.domain.wish.domain.service.WishUpdateService;
+import com.postgraduate.domain.wish.exception.MatchingNotReceiveException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UserManageByAdminUseCase {
     private final WishGetService wishGetService;
+    private final WishUpdateService wishUpdateService;
 
     public UserManageResponse getUsers(Integer page, String search) {
         Page<Wish> wishes = wishGetService.all(page, search);
@@ -32,5 +35,13 @@ public class UserManageByAdminUseCase {
     public WishResponse getWish(Long wishId) {
         Wish wish = wishGetService.byWishId(wishId);
         return AdminMapper.mapToWishResponse(wish);
+    }
+
+    public void updateWishStatus(Long wishId) {
+        Wish wish = wishGetService.byWishId(wishId);
+        if (!wish.getMatchingReceive()) {
+            throw new MatchingNotReceiveException();
+        }
+        wishUpdateService.updateWishStatus(wish);
     }
 }

--- a/src/main/java/com/postgraduate/domain/admin/presentation/AdminController.java
+++ b/src/main/java/com/postgraduate/domain/admin/presentation/AdminController.java
@@ -64,6 +64,13 @@ public class AdminController {
         return ResponseDto.create(ADMIN_FIND.getCode(), GET_DETAILS.getMessage(), wish);
     }
 
+    @PatchMapping("/wish/{wishId}")
+    @Operation(summary = "[관리자] 후배 매칭 지원 완료", description = "대학생 매칭지원을 완료합니다.")
+    public ResponseDto updateWishStatus(@PathVariable Long wishId) {
+        userManageUseCase.updateWishStatus(wishId);
+        return ResponseDto.create(ADMIN_UPDATE.getCode(), UPDATE_WISH_STATUS.getMessage());
+    }
+
     @GetMapping("/seniors")
     @Operation(summary = "[관리자] 선배 정보 목록", description = "대학원생 선배 정보 목록을 조회합니다.")
     public ResponseDto<SeniorManageResponse> getSeniors(@RequestParam(required = false) Integer page,

--- a/src/main/java/com/postgraduate/domain/admin/presentation/constant/AdminResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/admin/presentation/constant/AdminResponseMessage.java
@@ -9,7 +9,8 @@ public enum AdminResponseMessage {
     GET_DETAILS("상세 조회에 성공하였습니다."),
     GET_LIST("목록 조회에 성공하였습니다."),
     UPDATE_SENIOR_STATUS("선배 승인 상태 수정에 성공하였습니다."),
-    UPDATE_SALARY_STATUS("정산 상태 수정에 성공하였습니다.");
+    UPDATE_SALARY_STATUS("정산 상태 수정에 성공하였습니다."),
+    UPDATE_WISH_STATUS("매칭 지원 완료에 성공하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/postgraduate/domain/wish/application/mapper/WishMapper.java
+++ b/src/main/java/com/postgraduate/domain/wish/application/mapper/WishMapper.java
@@ -4,23 +4,28 @@ import com.postgraduate.domain.auth.application.dto.req.SignUpRequest;
 import com.postgraduate.domain.auth.application.dto.req.UserChangeRequest;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.wish.domain.entity.Wish;
+import com.postgraduate.domain.wish.domain.entity.constant.Status;
 
 public class WishMapper {
     public static Wish mapToWish(User user, SignUpRequest request) {
+        Status matchingStatus = request.matchingReceive() ? Status.WAITING : Status.REJECTED;
         return Wish.builder()
                 .user(user)
                 .major(request.major())
                 .field(request.field())
                 .matchingReceive(request.matchingReceive())
+                .status(matchingStatus)
                 .build();
     }
 
     public static Wish mapToWish(User user, UserChangeRequest request) {
+        Status matchingStatus = request.matchingReceive() ? Status.WAITING : Status.REJECTED;
         return Wish.builder()
                 .user(user)
                 .major(request.major())
                 .field(request.field())
                 .matchingReceive(request.matchingReceive())
+                .status(matchingStatus)
                 .build();
     }
 }

--- a/src/main/java/com/postgraduate/domain/wish/domain/entity/Wish.java
+++ b/src/main/java/com/postgraduate/domain/wish/domain/entity/Wish.java
@@ -1,6 +1,7 @@
 package com.postgraduate.domain.wish.domain.entity;
 
 import com.postgraduate.domain.user.domain.entity.User;
+import com.postgraduate.domain.wish.domain.entity.constant.Status;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,10 +29,10 @@ public class Wish {
     private User user;
 
     @Column(nullable = false)
-    @Builder.Default
-    private Boolean status = false;
+    @Enumerated(EnumType.STRING)
+    private Status status;
 
     public void updateStatus() {
-        this.status = true;
+        this.status = Status.MATCHED;
     }
 }

--- a/src/main/java/com/postgraduate/domain/wish/domain/entity/Wish.java
+++ b/src/main/java/com/postgraduate/domain/wish/domain/entity/Wish.java
@@ -26,4 +26,8 @@ public class Wish {
 
     @OneToOne
     private User user;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean status = false;
 }

--- a/src/main/java/com/postgraduate/domain/wish/domain/entity/Wish.java
+++ b/src/main/java/com/postgraduate/domain/wish/domain/entity/Wish.java
@@ -30,4 +30,8 @@ public class Wish {
     @Column(nullable = false)
     @Builder.Default
     private Boolean status = false;
+
+    public void updateStatus() {
+        this.status = true;
+    }
 }

--- a/src/main/java/com/postgraduate/domain/wish/domain/entity/constant/Status.java
+++ b/src/main/java/com/postgraduate/domain/wish/domain/entity/constant/Status.java
@@ -1,0 +1,5 @@
+package com.postgraduate.domain.wish.domain.entity.constant;
+
+public enum Status {
+    WAITING, MATCHED, REJECTED
+}

--- a/src/main/java/com/postgraduate/domain/wish/domain/service/WishUpdateService.java
+++ b/src/main/java/com/postgraduate/domain/wish/domain/service/WishUpdateService.java
@@ -1,0 +1,13 @@
+package com.postgraduate.domain.wish.domain.service;
+
+import com.postgraduate.domain.wish.domain.entity.Wish;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WishUpdateService {
+    public void updateWishStatus(Wish wish) {
+        wish.updateStatus();
+    }
+}

--- a/src/main/java/com/postgraduate/domain/wish/exception/MatchingNotReceiveException.java
+++ b/src/main/java/com/postgraduate/domain/wish/exception/MatchingNotReceiveException.java
@@ -1,0 +1,12 @@
+package com.postgraduate.domain.wish.exception;
+
+import com.postgraduate.domain.salary.exception.SalaryException;
+
+import static com.postgraduate.domain.wish.presentation.constant.WishResponseCode.MATCHING_NOT_RECEIVE;
+import static com.postgraduate.domain.wish.presentation.constant.WishResponseMessage.NOT_AGREE_MATCHING;
+
+public class MatchingNotReceiveException extends SalaryException {
+    public MatchingNotReceiveException() {
+        super(NOT_AGREE_MATCHING.getMessage(), MATCHING_NOT_RECEIVE.getCode());
+    }
+}

--- a/src/main/java/com/postgraduate/domain/wish/presentation/constant/WishResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/wish/presentation/constant/WishResponseCode.java
@@ -11,6 +11,7 @@ public enum WishResponseCode {
     WISH_CREATE("WSH202"),
     WISH_DELETE("WSH203"),
 
-    WISH_NOT_FOUND("EX200");
+    WISH_NOT_FOUND("EX200"),
+    MATCHING_NOT_RECEIVE("EX201");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/wish/presentation/constant/WishResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/wish/presentation/constant/WishResponseMessage.java
@@ -9,7 +9,8 @@ public enum WishResponseMessage {
     GET_WISH_INFO("지원 정보 조회에 성공하였습니다"),
     GET_WISH_LIST_INFO("지원 리스트 조회에 성공하였습니다."),
 
-    NOT_FOUND_WISH("지원을 찾을 수 없습니다.");
+    NOT_FOUND_WISH("지원을 찾을 수 없습니다."),
+    NOT_AGREE_MATCHING("매칭에 동의하지 않았습니다.");
 
     private final String message;
 }

--- a/src/test/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCaseTest.java
@@ -12,6 +12,7 @@ import com.postgraduate.domain.user.domain.service.UserGetService;
 import com.postgraduate.domain.user.domain.service.UserSaveService;
 import com.postgraduate.domain.user.domain.service.UserUpdateService;
 import com.postgraduate.domain.wish.domain.entity.Wish;
+import com.postgraduate.domain.wish.domain.entity.constant.Status;
 import com.postgraduate.domain.wish.domain.service.WishSaveService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -63,7 +64,7 @@ class SignUpUseCaseTest {
         user = new User(1L, 1234L, "a",
                 "a", "123", "a",
                 1, USER, TRUE, LocalDateTime.now(), LocalDateTime.now(), FALSE);
-        wish = new Wish(1L, "major", "field", TRUE, user);
+        wish = new Wish(1L, "major", "field", TRUE, user, Status.WAITING);
         senior = new Senior(1L, user, "a",
                 APPROVE, 1, info, profile,
                 LocalDateTime.now(), LocalDateTime.now());


### PR DESCRIPTION
## 🦝 PR 요약
+ 매칭 지원 기능을 구현했습니다.

## ✨ PR 상세 내용
+ `Wish` 엔티티에 매칭 지원 상태와 관련한 필드를 추가했습니다. (`status`)
+ 매칭 지원 완료하는 API를 구현했습니다.

## 🚨 주의 사항
관리자의 [후배회원] - [매칭지원완료] 칼럼은 
  + 빈칸
  + 대기중
  + 완료됨

으로 세 가지 입니다. `wish.status` 를 nullable 로 유지한 대신, '빈칸'의 경우 `wish.matchingReceive` 를 고려해 동의하지 않았다면 null 을 반환합니다. 혹시 더 나은 방법이 있다면 의견 주시면 감사하겠습니다 !

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
