### PR TITLE
RAC-250 fix : 전체 점검 및 수정

### DIFF
--- a/src/main/java/com/postgraduate/domain/auth/application/dto/res/AuthUserResponse.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/dto/res/AuthUserResponse.java
@@ -1,16 +1,9 @@
 package com.postgraduate.domain.auth.application.dto.res;
 
 import com.postgraduate.domain.user.domain.entity.User;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
 
-import java.util.Optional;
-
-@Builder
-@Getter
-@AllArgsConstructor
-public class AuthUserResponse {
-    private Optional<User> user;
-    private Long socialId;
+public record AuthUserResponse(User user, Long socialId) {
+    public AuthUserResponse(Long socialId) {
+        this(null, socialId);
+    }
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/mapper/AuthMapper.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/mapper/AuthMapper.java
@@ -6,10 +6,11 @@ import com.postgraduate.domain.user.domain.entity.User;
 import java.util.Optional;
 
 public class AuthMapper {
-    public static AuthUserResponse mapToAuthUser(Optional<User> user, Long socialId) {
-        return AuthUserResponse.builder()
-                .user(user)
-                .socialId(socialId)
-                .build();
+    public static AuthUserResponse mapToAuthUser(User user, Long socialId) {
+        return new AuthUserResponse(user, socialId);
+    }
+
+    public static AuthUserResponse mapToAuthUser(Long socialId) {
+        return new AuthUserResponse(socialId);
     }
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
@@ -8,6 +8,7 @@ import com.postgraduate.domain.senior.application.mapper.SeniorMapper;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorSaveService;
 import com.postgraduate.domain.user.application.mapper.UserMapper;
+import com.postgraduate.domain.user.application.utils.UserUtils;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.entity.constant.Role;
 import com.postgraduate.domain.user.domain.service.UserGetService;
@@ -29,8 +30,10 @@ public class SignUpUseCase {
     private final UserGetService userGetService;
     private final WishSaveService wishSaveService;
     private final SeniorSaveService seniorSaveService;
+    private final UserUtils userUtils;
 
     public User userSignUp(SignUpRequest request) {
+        userUtils.checkPhoneNumber(request.phoneNumber());
         User user = UserMapper.mapToUser(request);
         Wish wish = WishMapper.mapToWish(user, request);
         wishSaveService.saveWish(wish);
@@ -39,6 +42,7 @@ public class SignUpUseCase {
     }
 
     public User seniorSignUp(SeniorSignUpRequest request) {
+        userUtils.checkPhoneNumber(request.phoneNumber());
         User user = UserMapper.mapToUser(request);
         userSaveService.saveUser(user);
         Senior senior = SeniorMapper.mapToSenior(user, request);

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
@@ -5,6 +5,7 @@ import com.postgraduate.domain.auth.application.dto.req.SeniorSignUpRequest;
 import com.postgraduate.domain.auth.application.dto.req.SignUpRequest;
 import com.postgraduate.domain.auth.application.dto.req.UserChangeRequest;
 import com.postgraduate.domain.senior.application.mapper.SeniorMapper;
+import com.postgraduate.domain.senior.application.utils.SeniorUtils;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorSaveService;
 import com.postgraduate.domain.user.application.mapper.UserMapper;
@@ -31,6 +32,7 @@ public class SignUpUseCase {
     private final WishSaveService wishSaveService;
     private final SeniorSaveService seniorSaveService;
     private final UserUtils userUtils;
+    private final SeniorUtils seniorUtils;
 
     public User userSignUp(SignUpRequest request) {
         userUtils.checkPhoneNumber(request.phoneNumber());
@@ -42,6 +44,7 @@ public class SignUpUseCase {
     }
 
     public User seniorSignUp(SeniorSignUpRequest request) {
+        seniorUtils.checkKeyword(request.keyword());
         userUtils.checkPhoneNumber(request.phoneNumber());
         User user = UserMapper.mapToUser(request);
         userSaveService.saveUser(user);
@@ -51,6 +54,7 @@ public class SignUpUseCase {
     }
 
     public User changeSenior(User user, SeniorChangeRequest changeRequest) {
+        seniorUtils.checkKeyword(changeRequest.keyword());
         Senior senior = SeniorMapper.mapToSenior(user, changeRequest); //todo : 예외 처리
         seniorSaveService.saveSenior(senior);
         user = userGetService.getUser(user.getUserId());

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignInUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignInUseCase.java
@@ -7,11 +7,10 @@ import com.postgraduate.domain.auth.application.mapper.AuthMapper;
 import com.postgraduate.domain.auth.application.usecase.oauth.SignInUseCase;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.service.UserGetService;
+import com.postgraduate.domain.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,9 +21,13 @@ public class KakaoSignInUseCase implements SignInUseCase {
 
     @Override
     public AuthUserResponse getUser(CodeRequest codeRequest) {
-        KakaoUserInfoResponse userInfo = kakaoTokenUseCase.getAccessToken(codeRequest);
-        Long socialId = userInfo.id();
-        Optional<User> user = userGetService.bySocialId(socialId);
-        return AuthMapper.mapToAuthUser(user, socialId);
+            KakaoUserInfoResponse userInfo = kakaoTokenUseCase.getAccessToken(codeRequest);
+            Long socialId = userInfo.id();
+        try {
+            User user = userGetService.bySocialId(socialId);
+            return AuthMapper.mapToAuthUser(user, socialId);
+        } catch (UserNotFoundException e) {
+            return AuthMapper.mapToAuthUser(socialId);
+        }
     }
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignInUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignInUseCase.java
@@ -21,8 +21,8 @@ public class KakaoSignInUseCase implements SignInUseCase {
 
     @Override
     public AuthUserResponse getUser(CodeRequest codeRequest) {
-            KakaoUserInfoResponse userInfo = kakaoTokenUseCase.getAccessToken(codeRequest);
-            Long socialId = userInfo.id();
+        KakaoUserInfoResponse userInfo = kakaoTokenUseCase.getAccessToken(codeRequest);
+        Long socialId = userInfo.id();
         try {
             User user = userGetService.bySocialId(socialId);
             return AuthMapper.mapToAuthUser(user, socialId);

--- a/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
@@ -38,9 +38,9 @@ public class AuthController {
     public ResponseDto<?> authLogin(@RequestBody @Valid CodeRequest request, @PathVariable Provider provider) {
         SignInUseCase signInUseCase = selectOauth.selectSignIn(provider);
         AuthUserResponse authUser = signInUseCase.getUser(request);
-        if (authUser.getUser().isEmpty())
+        if (authUser.user() == null)
             return ResponseDto.create(AUTH_NONE.getCode(), NOT_REGISTERED_USER.getMessage(), authUser);
-        JwtTokenResponse jwtToken = jwtUseCase.signIn(authUser.getUser().get());
+        JwtTokenResponse jwtToken = jwtUseCase.signIn(authUser.user());
         return ResponseDto.create(AUTH_ALREADY.getCode(), SUCCESS_AUTH.getMessage(), jwtToken);
     }
 

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringApplyUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringApplyUseCase.java
@@ -4,6 +4,7 @@ import com.postgraduate.domain.mentoring.application.dto.req.MentoringApplyReque
 import com.postgraduate.domain.mentoring.application.mapper.MentoringMapper;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.mentoring.domain.service.MentoringSaveService;
+import com.postgraduate.domain.mentoring.exception.MentoringDateException;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
 import com.postgraduate.domain.user.domain.entity.User;
@@ -19,6 +20,9 @@ public class MentoringApplyUseCase {
     private final SeniorGetService seniorGetService;
 
     public void applyMentoring(User user, MentoringApplyRequest request) {
+        String[] dates = request.date().split(",");
+        if (dates.length != 3)
+            throw new MentoringDateException();
         Senior senior = seniorGetService.bySeniorId(request.seniorId());
         Mentoring mentoring = MentoringMapper.mapToMentoring(user, senior, request);
         mentoringSaveService.save(mentoring);

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseCase.java
@@ -88,13 +88,15 @@ public class MentoringManageUseCase {
 
     @Scheduled(cron = "0 59 23 * * *", zone = "Asia/Seoul")
     public void updateCancel() {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now()
+                .toLocalDate()
+                .atStartOfDay();
         List<Mentoring> mentorings = mentoringGetService.byStatusAndCreatedAt(WAITING, now);
         mentorings.forEach(mentoring -> {
-                    mentoringUpdateService.updateStatus(mentoring, CANCEL);
-                    Refuse refuse = RefuseMapper.mapToRefuse(mentoring);
-                    refuseSaveService.saveRefuse(refuse);
-                    //TODO : 알림 보내거나 나머지 작업
-                });
+            mentoringUpdateService.updateStatus(mentoring, CANCEL);
+            Refuse refuse = RefuseMapper.mapToRefuse(mentoring);
+            refuseSaveService.saveRefuse(refuse);
+            //TODO : 알림 보내거나 나머지 작업
+        });
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/entity/Mentoring.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/entity/Mentoring.java
@@ -12,6 +12,11 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static java.time.LocalDateTime.now;
+import static java.time.LocalDateTime.parse;
+import static java.time.format.DateTimeFormatter.ofPattern;
 
 @Entity
 @Builder
@@ -62,5 +67,12 @@ public class Mentoring {
 
     public void updateDate(String date) {
         this.date = date;
+    }
+
+    public boolean checkAutoDone() {
+        DateTimeFormatter formatter = ofPattern("yyyy-MM-dd-HH-mm");
+        LocalDateTime doneDate = parse(this.date, formatter);
+        return now().minusDays(2)
+                .isAfter(doneDate);
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
     Optional<Mentoring> findByMentoringIdAndUser_IsDeleteAndSenior_User_IsDelete(Long mentoringId, Boolean isUserDelete, Boolean isSeniorDelete);
     List<Mentoring> findAllByUserAndStatus(User user, Status status);
+    List<Mentoring> findAllByStatus(Status status);
     List<Mentoring> findAllBySeniorAndStatus(Senior senior, Status status);
     List<Mentoring> findAllByStatusAndCreatedAtIsBefore(Status status, LocalDateTime now);
     List<Mentoring> findAllByUser_UserId(Long userId);

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
@@ -36,6 +36,10 @@ public class MentoringGetService {
         return mentoringRepository.findAllByStatusAndCreatedAtIsBefore(status, now);
     }
 
+    public List<Mentoring> byStatus(Status status) {
+        return mentoringRepository.findAllByStatus(status);
+    }
+
     public List<Mentoring> byUserId(Long userId) {
         return mentoringRepository.findAllByUser_UserId(userId);
     }

--- a/src/main/java/com/postgraduate/domain/mentoring/exception/MentoringDateException.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/exception/MentoringDateException.java
@@ -1,0 +1,10 @@
+package com.postgraduate.domain.mentoring.exception;
+
+import com.postgraduate.domain.mentoring.presentation.constant.MentoringResponseCode;
+import com.postgraduate.domain.mentoring.presentation.constant.MentoringResponseMessage;
+
+public class MentoringDateException extends MentoringException {
+    public MentoringDateException() {
+        super(MentoringResponseMessage.INVALID_DATE.getMessage(), MentoringResponseCode.INVALID_DATE.getCode());
+    }
+}

--- a/src/main/java/com/postgraduate/domain/mentoring/presentation/constant/MentoringResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/presentation/constant/MentoringResponseCode.java
@@ -15,6 +15,7 @@ public enum MentoringResponseCode {
     MENTORING_DONE("EX701"),
     MENTORING_NOT_WAITING("EX702"),
     MENTORING_NOT_EXPECTED("EX703"),
+    INVALID_DATE("EX704"),
     ;
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/presentation/constant/MentoringResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/presentation/constant/MentoringResponseMessage.java
@@ -15,6 +15,7 @@ public enum MentoringResponseMessage {
     DONE_MENTORING("완료된 멘토링입니다."),
     NOT_WAITING_MENTORING("확정 대기 상태의 멘토링이 아닙니다."),
     NOT_EXPECTED_MENTORING("예정 상태의 멘토링이 아닙니다."),
+    INVALID_DATE("날짜가 잘못되었습니다."),
     ;
 
     private final String message;

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
@@ -9,6 +9,7 @@ import com.postgraduate.domain.available.domain.entity.Available;
 import com.postgraduate.domain.available.domain.service.AvailableSaveService;
 import com.postgraduate.domain.available.domain.service.AvailableDeleteService;
 import com.postgraduate.domain.senior.application.dto.req.*;
+import com.postgraduate.domain.senior.application.utils.SeniorUtils;
 import com.postgraduate.domain.senior.domain.entity.Profile;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
@@ -45,6 +46,7 @@ public class SeniorManageUseCase {
     private final AccountUpdateService accountUpdateService;
     private final EncryptorUtils encryptorUtils;
     private final UserUtils userUtils;
+    private final SeniorUtils seniorUtils;
 
     public void updateCertification(User user, SeniorCertificationRequest certificationRequest) {
         Senior senior = seniorGetService.byUser(user);
@@ -67,6 +69,7 @@ public class SeniorManageUseCase {
     }
 
     public void updateSeniorMyPageProfile(User user, SeniorMyPageProfileRequest myPageProfileRequest) {
+        seniorUtils.checkKeyword(myPageProfileRequest.keyword());
         Senior senior = seniorGetService.byUser(user);
         Profile profile = mapToProfile(myPageProfileRequest);
         seniorUpdateService.updateMyPageProfile(senior, myPageProfileRequest, profile);

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
@@ -14,6 +14,7 @@ import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
 import com.postgraduate.domain.senior.domain.service.SeniorUpdateService;
 import com.postgraduate.domain.senior.exception.NoneAccountException;
+import com.postgraduate.domain.user.application.utils.UserUtils;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.service.UserGetService;
 import com.postgraduate.domain.user.domain.service.UserUpdateService;
@@ -43,6 +44,7 @@ public class SeniorManageUseCase {
     private final AccountSaveService accountSaveService;
     private final AccountUpdateService accountUpdateService;
     private final EncryptorUtils encryptorUtils;
+    private final UserUtils userUtils;
 
     public void updateCertification(User user, SeniorCertificationRequest certificationRequest) {
         Senior senior = seniorGetService.byUser(user);
@@ -75,6 +77,7 @@ public class SeniorManageUseCase {
     }
 
     public void updateSeniorMyPageUserAccount(User user, SeniorMyPageUserAccountRequest myPageUserAccountRequest) {
+        userUtils.checkPhoneNumber(myPageUserAccountRequest.phoneNumber());
         Senior senior = seniorGetService.byUser(user);
         user = userGetService.getUser(user.getUserId());
         Optional<Account> optionalAccount = accountGetService.bySenior(senior);
@@ -91,6 +94,7 @@ public class SeniorManageUseCase {
     }
 
     private void updateSeniorMyPageUserAccountNoneAccount(Senior senior, User user, SeniorMyPageUserAccountRequest myPageUserAccountRequest) {
+        userUtils.checkPhoneNumber(myPageUserAccountRequest.phoneNumber());
         user = userGetService.getUser(user.getUserId());
         if (myPageUserAccountRequest.accountNumber().isEmpty() || myPageUserAccountRequest.accountHolder().isEmpty() || myPageUserAccountRequest.bank().isEmpty()) {
             userUpdateService.updateSeniorUserAccount(user, myPageUserAccountRequest);

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
@@ -97,7 +97,6 @@ public class SeniorManageUseCase {
     }
 
     private void updateSeniorMyPageUserAccountNoneAccount(Senior senior, User user, SeniorMyPageUserAccountRequest myPageUserAccountRequest) {
-        userUtils.checkPhoneNumber(myPageUserAccountRequest.phoneNumber());
         user = userGetService.getUser(user.getUserId());
         if (myPageUserAccountRequest.accountNumber().isEmpty() || myPageUserAccountRequest.accountHolder().isEmpty() || myPageUserAccountRequest.bank().isEmpty()) {
             userUpdateService.updateSeniorUserAccount(user, myPageUserAccountRequest);

--- a/src/main/java/com/postgraduate/domain/senior/application/utils/SeniorUtils.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/utils/SeniorUtils.java
@@ -1,0 +1,13 @@
+package com.postgraduate.domain.senior.application.utils;
+
+import com.postgraduate.domain.senior.exception.KeywordException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SeniorUtils {
+    public void checkKeyword(String keyword) {
+        String[] keywordCount = keyword.split(",");
+        if (keywordCount.length > 6)
+            throw new KeywordException();
+    }
+}

--- a/src/main/java/com/postgraduate/domain/senior/exception/KeywordException.java
+++ b/src/main/java/com/postgraduate/domain/senior/exception/KeywordException.java
@@ -1,0 +1,10 @@
+package com.postgraduate.domain.senior.exception;
+
+import com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode;
+import com.postgraduate.domain.senior.presentation.constant.SeniorResponseMessage;
+
+public class KeywordException extends SeniorException {
+    public KeywordException() {
+        super(SeniorResponseMessage.INVALID_KEYWORD.getMessage(), SeniorResponseCode.INVALID_KEYWORD.getCode());
+    }
+}

--- a/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseCode.java
@@ -13,6 +13,7 @@ public enum SeniorResponseCode {
 
     NONE_SENIOR("EX400"),
     NONE_ACCOUNT("EX401"),
-    NOT_WAITING_STATUS("EX402");
+    NOT_WAITING_STATUS("EX402"),
+    INVALID_KEYWORD("EX402");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseMessage.java
@@ -24,6 +24,7 @@ public enum SeniorResponseMessage {
 
     NONE_SENIOR("등록된 멘토가 없습니다."),
     NONE_ACCOUNT("계좌가 없습니다."),
+    INVALID_KEYWORD("키워드가 잘못되었습니다."),
     NOT_WAITING_STATUS("승인대기 상태의 선배가 아닙니다.");
 
     private final String message;

--- a/src/main/java/com/postgraduate/domain/user/application/usecase/UserManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/user/application/usecase/UserManageUseCase.java
@@ -1,6 +1,7 @@
 package com.postgraduate.domain.user.application.usecase;
 
 import com.postgraduate.domain.user.application.dto.req.UserInfoRequest;
+import com.postgraduate.domain.user.application.utils.UserUtils;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.service.UserGetService;
 import com.postgraduate.domain.user.domain.service.UserUpdateService;
@@ -8,16 +9,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Transactional
 @Service
 @RequiredArgsConstructor
 public class UserManageUseCase {
     private final UserUpdateService userUpdateService;
     private final UserGetService userGetService;
+    private final UserUtils userUtils;
 
     public void updateInfo(User user, UserInfoRequest userInfoRequest) {
+        userUtils.checkPhoneNumber(userInfoRequest.getPhoneNumber());
         user = userGetService.getUser(user.getUserId());
         userUpdateService.updateInfo(user, userInfoRequest);
     }

--- a/src/main/java/com/postgraduate/domain/user/application/utils/UserUtils.java
+++ b/src/main/java/com/postgraduate/domain/user/application/utils/UserUtils.java
@@ -1,0 +1,22 @@
+package com.postgraduate.domain.user.application.utils;
+
+import com.postgraduate.domain.user.domain.service.UserGetService;
+import com.postgraduate.domain.user.exception.PhoneNumberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class UserUtils {
+    private final UserGetService userGetService;
+
+    public void checkPhoneNumber(String phoneNumber) {
+        if (phoneNumber.length() != 11)
+            throw new PhoneNumberException();
+        try {
+            Long.parseLong(phoneNumber);
+        } catch (Exception e) {
+            throw new PhoneNumberException();
+        }
+    }
+}

--- a/src/main/java/com/postgraduate/domain/user/application/utils/UserUtils.java
+++ b/src/main/java/com/postgraduate/domain/user/application/utils/UserUtils.java
@@ -1,6 +1,5 @@
 package com.postgraduate.domain.user.application.utils;
 
-import com.postgraduate.domain.user.domain.service.UserGetService;
 import com.postgraduate.domain.user.exception.PhoneNumberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -8,8 +7,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Component
 public class UserUtils {
-    private final UserGetService userGetService;
-
     public void checkPhoneNumber(String phoneNumber) {
         if (phoneNumber.length() != 11)
             throw new PhoneNumberException();

--- a/src/main/java/com/postgraduate/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/service/UserGetService.java
@@ -19,8 +19,8 @@ public class UserGetService {
         return user;
     }
 
-    public Optional<User> bySocialId(Long socialId) {
-        return userRepository.findBySocialId(socialId);
+    public User bySocialId(Long socialId) {
+        return userRepository.findBySocialId(socialId).orElseThrow(UserNotFoundException::new);
     }
 
     public Optional<User> byNickName(String nickName) {

--- a/src/main/java/com/postgraduate/domain/user/exception/PhoneNumberException.java
+++ b/src/main/java/com/postgraduate/domain/user/exception/PhoneNumberException.java
@@ -1,0 +1,10 @@
+package com.postgraduate.domain.user.exception;
+
+import com.postgraduate.domain.user.presentation.constant.UserResponseCode;
+import com.postgraduate.domain.user.presentation.constant.UserResponseMessage;
+
+public class PhoneNumberException extends UserException{
+    public PhoneNumberException() {
+        super(UserResponseMessage.INVALID_PHONE_NUMBER.getMessage(), UserResponseCode.INVALID_PHONE_NUMBER.getCode());
+    }
+}

--- a/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseCode.java
@@ -12,6 +12,7 @@ public enum UserResponseCode {
     USER_DELETE("UR203"),
 
     USER_NOT_FOUND("EX300"),
-    DELETED_USER("EX301");
+    DELETED_USER("EX301"),
+    INVALID_PHONE_NUMBER("EX302");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseMessage.java
@@ -13,6 +13,7 @@ public enum UserResponseMessage {
     UPDATE_USER_INFO("사용자 업데이트에 성공하였습니다."),
 
     NOT_FOUND_USER("등록된 사용자가 없습니다."),
+    INVALID_PHONE_NUMBER("잘못된 번호입니다."),
     DELETED_USER("탈퇴한 사용자 입니다.");
 
     private final String message;

--- a/src/test/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignInUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignInUseCaseTest.java
@@ -5,6 +5,7 @@ import com.postgraduate.domain.auth.application.dto.res.AuthUserResponse;
 import com.postgraduate.domain.auth.application.dto.res.KakaoUserInfoResponse;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.service.UserGetService;
+import com.postgraduate.domain.user.exception.UserNotFoundException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,12 +16,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import static com.postgraduate.domain.auth.application.dto.res.KakaoUserInfoResponse.KakaoAccount;
 import static com.postgraduate.domain.user.domain.entity.constant.Role.USER;
 import static java.lang.Boolean.TRUE;
-import static java.time.LocalDate.now;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,12 +49,11 @@ class KakaoSignInUseCaseTest {
         given(kakaoAccessTokenUseCase.getAccessToken(codeRequest))
                 .willReturn(kakaoUserInfoResponse);
         given(userGetService.bySocialId(kakaoUserInfoResponse.id()))
-                .willReturn(Optional.of(user));
+                .willReturn(user);
 
         AuthUserResponse authUserResponse = kakaoSignInUseCase.getUser(codeRequest);
 
-        Assertions.assertThat(authUserResponse.getUser())
-                .isNotEmpty();
+        Assertions.assertThat(authUserResponse.user()).isNotNull();
     }
 
     @Test
@@ -68,11 +66,11 @@ class KakaoSignInUseCaseTest {
         given(kakaoAccessTokenUseCase.getAccessToken(codeRequest))
                 .willReturn(kakaoUserInfoResponse);
         given(userGetService.bySocialId(kakaoUserInfoResponse.id()))
-                .willReturn(Optional.ofNullable(null));
+                .willThrow(UserNotFoundException.class);
 
         AuthUserResponse authUserResponse = kakaoSignInUseCase.getUser(codeRequest);
 
-        Assertions.assertThat(authUserResponse.getUser())
-                .isEmpty();
+        Assertions.assertThat(authUserResponse.user())
+                .isNull();
     }
 }

--- a/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringApplyUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringApplyUseCaseTest.java
@@ -3,16 +3,20 @@ package com.postgraduate.domain.mentoring.application.usecase;
 import com.postgraduate.domain.mentoring.application.dto.req.MentoringApplyRequest;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.mentoring.domain.service.MentoringSaveService;
+import com.postgraduate.domain.mentoring.exception.MentoringDateException;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
 import com.postgraduate.domain.user.domain.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -31,10 +35,10 @@ class MentoringApplyUseCaseTest {
     private MentoringApplyUseCase mentoringApplyUseCase;
 
     @Test
-    @DisplayName("실행 여부 테스트")
+    @DisplayName("정상 실행 여부 테스트")
     void applyMentoring() {
         User user = mock(User.class);
-        MentoringApplyRequest request = new MentoringApplyRequest(-1L, "topic", "ques", "1201");
+        MentoringApplyRequest request = new MentoringApplyRequest(-1L, "topic", "ques", "1201,1202,1203");
 
         Senior senior = mock(Senior.class);
         given(seniorGetService.bySeniorId(request.seniorId()))
@@ -42,5 +46,27 @@ class MentoringApplyUseCaseTest {
         mentoringApplyUseCase.applyMentoring(user, request);
 
         verify(mentoringSaveService).save(any(Mentoring.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1201,1203", "1201", ""})
+    @DisplayName("날짜 예외 테스트 3보다 작을 경우")
+    void applyMentoringWithInvalidDatesSmaller(String dates) {
+        User user = mock(User.class);
+        MentoringApplyRequest request = new MentoringApplyRequest(-1L, "topic", "ques", dates);
+
+        assertThatThrownBy(()-> mentoringApplyUseCase.applyMentoring(user, request))
+                .isInstanceOf(MentoringDateException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1201,1203,1202,1203", "1201,1202,1203,1204,1205","1201,1202,1203,1204,1205,1206"})
+    @DisplayName("날짜 예외 테스트 3보다 큰 경우")
+    void applyMentoringWithInvalidDateBigger(String dates) {
+        User user = mock(User.class);
+        MentoringApplyRequest request = new MentoringApplyRequest(-1L, "topic", "ques", dates);
+
+        assertThatThrownBy(()-> mentoringApplyUseCase.applyMentoring(user, request))
+                .isInstanceOf(MentoringDateException.class);
     }
 }

--- a/src/test/java/com/postgraduate/domain/senior/application/utils/SeniorUtilsTest.java
+++ b/src/test/java/com/postgraduate/domain/senior/application/utils/SeniorUtilsTest.java
@@ -1,0 +1,34 @@
+package com.postgraduate.domain.senior.application.utils;
+
+import com.postgraduate.domain.senior.exception.KeywordException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class SeniorUtilsTest {
+    @InjectMocks
+    SeniorUtils seniorUtils;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a,b,c,d,e,f,g","a,b,c,d,e,f,g,h","a,b,c,d,e,f,g,h,i"})
+    @DisplayName("키워드 예외 테스트")
+    void invalidKeyword(String keywords) {
+        assertThatThrownBy(() -> seniorUtils.checkKeyword(keywords))
+                .isInstanceOf(KeywordException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a,b,c,d,e,f","1,2,3,4,5,6","abcd,efg,abc,qwe,123,agd"})
+    @DisplayName("키워드 성공 테스트")
+    void KeywordTest(String keywords) {
+        assertDoesNotThrow(() -> seniorUtils.checkKeyword(keywords));
+    }
+}

--- a/src/test/java/com/postgraduate/domain/user/application/usecase/UserManageUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/user/application/usecase/UserManageUseCaseTest.java
@@ -1,0 +1,49 @@
+package com.postgraduate.domain.user.application.usecase;
+
+import com.postgraduate.domain.user.application.dto.req.UserInfoRequest;
+import com.postgraduate.domain.user.application.utils.UserUtils;
+import com.postgraduate.domain.user.domain.entity.User;
+import com.postgraduate.domain.user.domain.service.UserGetService;
+import com.postgraduate.domain.user.domain.service.UserUpdateService;
+import com.postgraduate.domain.user.exception.PhoneNumberException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class UserManageUseCaseTest {
+    @Mock
+    UserUpdateService userUpdateService;
+    @Mock
+    UserGetService userGetService;
+    @Mock
+    UserUtils userUtils;
+    @InjectMocks
+    UserManageUseCase userManageUseCase;
+
+    @Test
+    @DisplayName("phoenumber 예외 테스트")
+    void invalidPhoneNumber() {
+        User user = mock(User.class);
+        UserInfoRequest request = new UserInfoRequest("a", "b", "c");
+
+        doThrow(PhoneNumberException.class)
+                .when(userUtils)
+                .checkPhoneNumber(request.getPhoneNumber());
+
+        assertThatThrownBy(() -> userManageUseCase.updateInfo(user, request))
+                .isInstanceOf(PhoneNumberException.class);
+    }
+}

--- a/src/test/java/com/postgraduate/domain/user/application/utils/UserUtilsTest.java
+++ b/src/test/java/com/postgraduate/domain/user/application/utils/UserUtilsTest.java
@@ -1,0 +1,34 @@
+package com.postgraduate.domain.user.application.utils;
+
+import com.postgraduate.domain.user.exception.PhoneNumberException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserUtilsTest {
+    @InjectMocks
+    UserUtils userUtils;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0101234123", "0101234", "010123412341", "010", "0101234123412", "abcabcdabcd"})
+    @DisplayName("핸드폰 번호 예외 테스트")
+    void invalidPhoneNumber(String phoneNumber) {
+        assertThatThrownBy(() -> userUtils.checkPhoneNumber(phoneNumber))
+                .isInstanceOf(PhoneNumberException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"01012341234", "01012344321"})
+    @DisplayName("핸드폰 번호 성공 테스트")
+    void phoneNumberTest(String phoneNumber) {
+        assertDoesNotThrow(() -> userUtils.checkPhoneNumber(phoneNumber));
+    }
+}


### PR DESCRIPTION
## 🦝 PR 요약
전체 점검 및 수정

## ✨ PR 상세 내용
- 핸드폰 번호 아무거나 입력해도 저장되는 문제 해결
숫자 8개 이외에 예외 처리 (가입, 업데이트 등등)
- 선배 키워드 6개 넘어가도 저장되는 문제 해결
키워드 6개 초과시 예외 처리 (가입, 업데이트 등등)
- 후배 멘토링 신청시 일정 3개 이외에 예외 처리
- 멘토링 완료 버튼을 누르지 않아도 48시간이 지나면 자동으로 완료 탭 (수정하여 처리)
48시간 딱 맞추기 어려워서 이 또한 마찬가지로 특정 시간에 48시간 이상 초과되었다면 완료로 바꾸고 Salary생성하도록 작업
- 이외에 몇가지 자잘한 수정이 있습니다.
- 각 작업에 맞춰 테스트 코드 작성

## 🚨 주의 사항
필드에 Optional이 들어가거나 Optional을 파라미터로 넘겨주는 것은 안티패턴 중 하나라고 합니다.
근데 회원가입 과정에서 필드에도 들어있고 파라미터로도 넘겨줍니다....ㅎ... 아까 지적받아서 알았어요...
이 부분에 대해서 우선은 null일 경우 service에서 예외를 터뜨리고 그 예외를 잡아서 DTO에 Opitonal이 아닌 user혹은 null이 들어가도록 그냥 
```java
@Override
    public AuthUserResponse getUser(CodeRequest codeRequest) {
            KakaoUserInfoResponse userInfo = kakaoTokenUseCase.getAccessToken(codeRequest);
            Long socialId = userInfo.id();
        try {
            User user = userGetService.bySocialId(socialId);
            return AuthMapper.mapToAuthUser(user, socialId);
        } catch (UserNotFoundException e) {
            return AuthMapper.mapToAuthUser(socialId);
        }
    }
```
이런식으로 처리하도록 하고 controller에서 user.isEmpty()가 아닌 user == null 이걸로 처리하도록 했는데 찝찝하긴 합니다...

만약 이 모든걸 깔끔하게 해결하고자 한다면 API를 3개로 쪼개면 좋을 것 같기는한데, 프론트 수정도 필요하고 여러모로 고민하다가 우선은 그렇게 넘기지는 않았습니다

**이 부분에 대해서 어떻게 생각하시나요?**

## ✅ 체크 리스트
- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
