### PR TITLE
RAC-251 fix: 전체점검

### DIFF
--- a/src/main/java/com/postgraduate/domain/admin/application/mapper/AdminMapper.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/mapper/AdminMapper.java
@@ -39,10 +39,6 @@ public class AdminMapper {
     public static UserInfo mapToUserInfo(Wish wish) {
         User user = wish.getUser();
         Boolean isSenior = user.getRole() == Role.SENIOR;
-        Long wishId = wish.getWishId();
-        if (wish.getMajor() == null && wish.getField() == null) {
-            wishId = null;
-        }
         return new UserInfo(
                 user.getUserId(),
                 user.getNickName(),
@@ -50,7 +46,7 @@ public class AdminMapper {
                 user.getCreatedAt(),
                 user.getMarketingReceive(),
                 wish.getMatchingReceive(),
-                wishId,
+                wish.getWishId(),
                 wish.getStatus(),
                 isSenior
         );

--- a/src/main/java/com/postgraduate/domain/admin/application/mapper/AdminMapper.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/mapper/AdminMapper.java
@@ -2,10 +2,12 @@ package com.postgraduate.domain.admin.application.mapper;
 
 import com.postgraduate.domain.account.domain.entity.Account;
 import com.postgraduate.domain.admin.application.dto.*;
-import com.postgraduate.domain.admin.application.dto.res.*;
+import com.postgraduate.domain.admin.application.dto.res.CertificationDetailsResponse;
+import com.postgraduate.domain.admin.application.dto.res.MentoringWithPaymentResponse;
+import com.postgraduate.domain.admin.application.dto.res.SalaryDetailsResponse;
+import com.postgraduate.domain.admin.presentation.constant.SalaryStatus;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.payment.domain.entity.Payment;
-import com.postgraduate.domain.admin.presentation.constant.SalaryStatus;
 import com.postgraduate.domain.senior.domain.entity.Info;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
@@ -68,7 +70,18 @@ public class AdminMapper {
     }
 
     public static MentoringInfo mapToMentoringInfo(Mentoring mentoring) {
-         User user = mentoring.getUser();
+        User user = mentoring.getUser();
+        return new MentoringInfo(
+                mentoring.getMentoringId(),
+                mentoring.getStatus(),
+                user.getNickName(),
+                user.getPhoneNumber(),
+                mentoring.getCreatedAt()
+        );
+    }
+
+    public static MentoringInfo mapToSeniorMentoringInfo(Mentoring mentoring) {
+        User user = mentoring.getSenior().getUser();
         return new MentoringInfo(
                 mentoring.getMentoringId(),
                 mentoring.getStatus(),

--- a/src/main/java/com/postgraduate/domain/admin/application/mapper/AdminMapper.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/mapper/AdminMapper.java
@@ -37,6 +37,10 @@ public class AdminMapper {
     public static UserInfo mapToUserInfo(Wish wish) {
         User user = wish.getUser();
         Boolean isSenior = user.getRole() == Role.SENIOR;
+        Long wishId = wish.getWishId();
+        if (wish.getMajor() == null && wish.getField() == null) {
+            wishId = null;
+        }
         return new UserInfo(
                 user.getUserId(),
                 user.getNickName(),
@@ -44,7 +48,7 @@ public class AdminMapper {
                 user.getCreatedAt(),
                 user.getMarketingReceive(),
                 wish.getMatchingReceive(),
-                wish.getWishId(),
+                wishId,
                 wish.getStatus(),
                 isSenior
         );

--- a/src/main/java/com/postgraduate/domain/admin/application/usecase/MentoringManageByAdminUseCase.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/usecase/MentoringManageByAdminUseCase.java
@@ -66,5 +66,6 @@ public class MentoringManageByAdminUseCase {
         mentoringUpdateService.updateStatus(mentoring, Status.CANCEL);
         Payment payment = paymentGetService.byMentoring(mentoring);
         paymentUpdateService.updateStatus(payment, CANCEL);
+        //todo: 결제 취소 로직 추가
     }
 }

--- a/src/main/java/com/postgraduate/domain/admin/application/usecase/MentoringManageByAdminUseCase.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/usecase/MentoringManageByAdminUseCase.java
@@ -38,7 +38,7 @@ public class MentoringManageByAdminUseCase {
     public MentoringManageResponse getUserMentorings(Long userId) {
         List<Mentoring> mentorings = mentoringGetService.byUserId(userId);
         List<MentoringInfo> mentoringInfos = mentorings.stream()
-                .map(AdminMapper::mapToMentoringInfo)
+                .map(AdminMapper::mapToSeniorMentoringInfo)
                 .toList();
         User user = userGetService.getUser(userId);
         UserMentoringInfo userMentoringInfo = AdminMapper.mapToUserMentoringInfo(user);

--- a/src/main/java/com/postgraduate/domain/admin/application/usecase/MentoringManageByAdminUseCase.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/usecase/MentoringManageByAdminUseCase.java
@@ -6,9 +6,12 @@ import com.postgraduate.domain.admin.application.dto.res.MentoringManageResponse
 import com.postgraduate.domain.admin.application.dto.res.MentoringWithPaymentResponse;
 import com.postgraduate.domain.admin.application.mapper.AdminMapper;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
+import com.postgraduate.domain.mentoring.domain.entity.constant.Status;
 import com.postgraduate.domain.mentoring.domain.service.MentoringGetService;
+import com.postgraduate.domain.mentoring.domain.service.MentoringUpdateService;
 import com.postgraduate.domain.payment.domain.entity.Payment;
 import com.postgraduate.domain.payment.domain.service.PaymentGetService;
+import com.postgraduate.domain.payment.domain.service.PaymentUpdateService;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
 import com.postgraduate.domain.user.domain.entity.User;
@@ -19,14 +22,19 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.postgraduate.domain.payment.domain.entity.constant.Status.CANCEL;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class MentoringManageByAdminUseCase {
     private final MentoringGetService mentoringGetService;
+    private final MentoringUpdateService mentoringUpdateService;
     private final UserGetService userGetService;
     private final SeniorGetService seniorGetService;
     private final PaymentGetService paymentGetService;
+    private final PaymentUpdateService paymentUpdateService;
+
     public MentoringManageResponse getUserMentorings(Long userId) {
         List<Mentoring> mentorings = mentoringGetService.byUserId(userId);
         List<MentoringInfo> mentoringInfos = mentorings.stream()
@@ -51,5 +59,12 @@ public class MentoringManageByAdminUseCase {
         Mentoring mentoring = mentoringGetService.byMentoringId(mentoringId);
         Payment payment = paymentGetService.byMentoring(mentoring);
         return AdminMapper.mapToMentoringWithPaymentResponse(payment, mentoring);
+    }
+
+    public void cancelMentoring(Long mentoringId) {
+        Mentoring mentoring = mentoringGetService.byMentoringId(mentoringId);
+        mentoringUpdateService.updateStatus(mentoring, Status.CANCEL);
+        Payment payment = paymentGetService.byMentoring(mentoring);
+        paymentUpdateService.updateStatus(payment, CANCEL);
     }
 }

--- a/src/main/java/com/postgraduate/domain/admin/application/usecase/UserManageByAdminUseCase.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/usecase/UserManageByAdminUseCase.java
@@ -46,6 +46,9 @@ public class UserManageByAdminUseCase {
         if (!wish.getMatchingReceive()) {
             throw new MatchingNotReceiveException();
         }
+        if (wish.getMajor() == null && wish.getField() == null) {
+            throw new WishEmptyException();
+        }
         wishUpdateService.updateWishStatus(wish);
     }
 }

--- a/src/main/java/com/postgraduate/domain/admin/application/usecase/UserManageByAdminUseCase.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/usecase/UserManageByAdminUseCase.java
@@ -8,6 +8,7 @@ import com.postgraduate.domain.wish.domain.entity.Wish;
 import com.postgraduate.domain.wish.domain.service.WishGetService;
 import com.postgraduate.domain.wish.domain.service.WishUpdateService;
 import com.postgraduate.domain.wish.exception.MatchingNotReceiveException;
+import com.postgraduate.domain.wish.exception.WishEmptyException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,9 @@ public class UserManageByAdminUseCase {
 
     public WishResponse getWish(Long wishId) {
         Wish wish = wishGetService.byWishId(wishId);
+        if (wish.getMajor() == null && wish.getField() == null) {
+            throw new WishEmptyException();
+        }
         return AdminMapper.mapToWishResponse(wish);
     }
 

--- a/src/main/java/com/postgraduate/domain/admin/application/usecase/UserManageByAdminUseCase.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/usecase/UserManageByAdminUseCase.java
@@ -35,6 +35,9 @@ public class UserManageByAdminUseCase {
 
     public WishResponse getWish(Long wishId) {
         Wish wish = wishGetService.byWishId(wishId);
+        if (!wish.getMatchingReceive()) {
+            throw new MatchingNotReceiveException();
+        }
         return AdminMapper.mapToWishResponse(wish);
     }
 

--- a/src/main/java/com/postgraduate/domain/admin/application/usecase/UserManageByAdminUseCase.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/usecase/UserManageByAdminUseCase.java
@@ -35,9 +35,6 @@ public class UserManageByAdminUseCase {
 
     public WishResponse getWish(Long wishId) {
         Wish wish = wishGetService.byWishId(wishId);
-        if (wish.getMajor() == null && wish.getField() == null) {
-            throw new WishEmptyException();
-        }
         return AdminMapper.mapToWishResponse(wish);
     }
 

--- a/src/main/java/com/postgraduate/domain/admin/application/usecase/UserManageByAdminUseCase.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/usecase/UserManageByAdminUseCase.java
@@ -7,7 +7,6 @@ import com.postgraduate.domain.wish.application.mapper.dto.res.WishResponse;
 import com.postgraduate.domain.wish.domain.entity.Wish;
 import com.postgraduate.domain.wish.domain.service.WishGetService;
 import com.postgraduate.domain.wish.domain.service.WishUpdateService;
-import com.postgraduate.domain.wish.exception.MatchingNotReceiveException;
 import com.postgraduate.domain.wish.exception.WishEmptyException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -35,17 +34,11 @@ public class UserManageByAdminUseCase {
 
     public WishResponse getWish(Long wishId) {
         Wish wish = wishGetService.byWishId(wishId);
-        if (!wish.getMatchingReceive()) {
-            throw new MatchingNotReceiveException();
-        }
         return AdminMapper.mapToWishResponse(wish);
     }
 
     public void updateWishStatus(Long wishId) {
         Wish wish = wishGetService.byWishId(wishId);
-        if (!wish.getMatchingReceive()) {
-            throw new MatchingNotReceiveException();
-        }
         if (wish.getMajor() == null && wish.getField() == null) {
             throw new WishEmptyException();
         }

--- a/src/main/java/com/postgraduate/domain/admin/presentation/AdminController.java
+++ b/src/main/java/com/postgraduate/domain/admin/presentation/AdminController.java
@@ -3,6 +3,7 @@ package com.postgraduate.domain.admin.presentation;
 import com.postgraduate.domain.admin.application.dto.req.SeniorStatusRequest;
 import com.postgraduate.domain.admin.application.dto.res.*;
 import com.postgraduate.domain.admin.application.usecase.*;
+import com.postgraduate.domain.admin.presentation.constant.AdminResponseMessage;
 import com.postgraduate.domain.wish.application.mapper.dto.res.WishResponse;
 import com.postgraduate.global.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -113,6 +114,13 @@ public class AdminController {
     public ResponseDto<MentoringManageResponse> getSeniorMentorings(@PathVariable Long seniorId) {
         MentoringManageResponse mentorings = mentoringManageUseCase.getSeniorMentorings(seniorId);
         return ResponseDto.create(ADMIN_FIND.getCode(), GET_LIST.getMessage(), mentorings);
+    }
+
+    @PatchMapping("/mentoring/{mentoringId}")
+    @Operation(summary = "[관리자] 멘토링 취소 및 환불", description = "멘토링을 취소 및 환불합니다.")
+    public ResponseDto cancelMentoring(@PathVariable Long mentoringId) {
+        mentoringManageUseCase.cancelMentoring(mentoringId);
+        return ResponseDto.create(ADMIN_UPDATE.getCode(), UPDATE_MENTORING_STATUS.getMessage());
     }
 
     @GetMapping("/payments")

--- a/src/main/java/com/postgraduate/domain/admin/presentation/constant/AdminResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/admin/presentation/constant/AdminResponseMessage.java
@@ -10,7 +10,8 @@ public enum AdminResponseMessage {
     GET_LIST("목록 조회에 성공하였습니다."),
     UPDATE_SENIOR_STATUS("선배 승인 상태 수정에 성공하였습니다."),
     UPDATE_SALARY_STATUS("정산 상태 수정에 성공하였습니다."),
-    UPDATE_WISH_STATUS("매칭 지원 완료에 성공하였습니다.");
+    UPDATE_WISH_STATUS("매칭 지원 완료에 성공하였습니다."),
+    UPDATE_MENTORING_STATUS("멘토링 상태 변경에 성공하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/postgraduate/domain/available/application/dto/res/AvailableTimesResponse.java
+++ b/src/main/java/com/postgraduate/domain/available/application/dto/res/AvailableTimesResponse.java
@@ -1,7 +1,9 @@
 package com.postgraduate.domain.available.application.dto.res;
 
-import jakarta.validation.constraints.NotNull;
-
 import java.util.List;
 
-public record AvailableTimesResponse (@NotNull List<AvailableTimeResponse> times){}
+public record AvailableTimesResponse(
+        String nickName,
+        List<AvailableTimeResponse> times
+) {
+}

--- a/src/main/java/com/postgraduate/domain/payment/domain/entity/Payment.java
+++ b/src/main/java/com/postgraduate/domain/payment/domain/entity/Payment.java
@@ -35,4 +35,9 @@ public class Payment {
     @Column(nullable = false)
     @Builder.Default
     private Status status = Status.IMPOSSIBLE;
+
+    public void updateStatus(Status status) {
+        this.status = status;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/postgraduate/domain/payment/domain/service/PaymentUpdateService.java
+++ b/src/main/java/com/postgraduate/domain/payment/domain/service/PaymentUpdateService.java
@@ -1,0 +1,15 @@
+package com.postgraduate.domain.payment.domain.service;
+
+import com.postgraduate.domain.payment.domain.entity.constant.Status;
+import com.postgraduate.domain.payment.domain.entity.Payment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentUpdateService {
+
+    public void updateStatus(Payment payment, Status status) {
+        payment.updateStatus(status);
+    }
+}

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/AllSeniorSearchResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/AllSeniorSearchResponse.java
@@ -4,4 +4,10 @@ import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
-public record AllSeniorSearchResponse(@NotNull List<SeniorSearchResponse> seniorSearchResponses) {}
+public record AllSeniorSearchResponse(
+        @NotNull
+        List<SeniorSearchResponse> seniorSearchResponses,
+        @NotNull
+        Long totalElements
+) {
+}

--- a/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorProfileResponse.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/dto/res/SeniorProfileResponse.java
@@ -12,5 +12,8 @@ public record SeniorProfileResponse(
         @NotNull
         String major,
         @NotNull
-        String lab
-) { }
+        String lab,
+        @NotNull
+        Integer term
+) {
+}

--- a/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/mapper/SeniorMapper.java
@@ -187,7 +187,8 @@ public class SeniorMapper {
     public static SeniorProfileResponse mapToSeniorProfile(Senior senior) {
         User user = senior.getUser();
         Info info = senior.getInfo();
+        Profile profile = senior.getProfile();
         return new SeniorProfileResponse(user.getNickName(), user.getProfile(),
-                info.getPostgradu(), info.getMajor(), info.getLab());
+                info.getPostgradu(), info.getMajor(), info.getLab(), profile.getTerm());
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
@@ -71,6 +71,6 @@ public class SeniorInfoUseCase {
         List<AvailableTimeResponse> times = availables.stream()
                 .map(AvailableMapper::mapToAvailableTimes)
                 .toList();
-        return new AvailableTimesResponse(times);
+        return new AvailableTimesResponse(senior.getUser().getNickName(), times);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseCase.java
@@ -5,7 +5,10 @@ import com.postgraduate.domain.available.application.dto.res.AvailableTimesRespo
 import com.postgraduate.domain.available.application.mapper.AvailableMapper;
 import com.postgraduate.domain.available.domain.entity.Available;
 import com.postgraduate.domain.available.domain.service.AvailableGetService;
-import com.postgraduate.domain.senior.application.dto.res.*;
+import com.postgraduate.domain.senior.application.dto.res.AllSeniorSearchResponse;
+import com.postgraduate.domain.senior.application.dto.res.SeniorDetailResponse;
+import com.postgraduate.domain.senior.application.dto.res.SeniorProfileResponse;
+import com.postgraduate.domain.senior.application.dto.res.SeniorSearchResponse;
 import com.postgraduate.domain.senior.application.mapper.SeniorMapper;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
@@ -17,7 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.postgraduate.domain.senior.application.mapper.SeniorMapper.*;
+import static com.postgraduate.domain.senior.application.mapper.SeniorMapper.mapToSeniorDetail;
+import static com.postgraduate.domain.senior.application.mapper.SeniorMapper.mapToSeniorProfile;
 
 @Service
 @Transactional
@@ -42,7 +46,8 @@ public class SeniorInfoUseCase {
         List<SeniorSearchResponse> selectSeniors = seniors.stream()
                 .map(SeniorMapper::mapToSeniorSearch)
                 .toList();
-        return new AllSeniorSearchResponse(selectSeniors);
+        long totalElements = seniors.getTotalElements();
+        return new AllSeniorSearchResponse(selectSeniors, totalElements);
     }
 
     public AllSeniorSearchResponse getFieldSenior(String field, String postgradu, Integer page) {
@@ -50,7 +55,8 @@ public class SeniorInfoUseCase {
         List<SeniorSearchResponse> selectSeniors = seniors.stream()
                 .map(SeniorMapper::mapToSeniorSearch)
                 .toList();
-        return new AllSeniorSearchResponse(selectSeniors);
+        long totalElements = seniors.getTotalElements();
+        return new AllSeniorSearchResponse(selectSeniors, totalElements);
     }
 
     public SeniorProfileResponse getSeniorProfile(Long seniorId) {

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -90,21 +90,21 @@ public class SeniorController {
     }
 
     @GetMapping("/{seniorId}")
-    @Operation(summary = "대학원생 상세 조회")
+    @Operation(summary = "대학원생 상세 조회 | 토큰 필요")
     public ResponseDto<SeniorDetailResponse> getSeniorDetails(@PathVariable Long seniorId) {
         SeniorDetailResponse seniorDetail = seniorInfoUseCase.getSeniorDetail(seniorId);
         return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_INFO.getMessage(), seniorDetail);
     }
 
     @GetMapping("/{seniorId}/profile")
-    @Operation(summary = "대학원생 닉네임~연구실 등 기본 정보 확인", description = "신청서 완료 후 결제시 노출 필요")
+    @Operation(summary = "대학원생 닉네임~연구실 등 기본 정보 확인 | 토큰 필요", description = "신청서 완료 후 결제시 노출 필요")
     public ResponseDto<SeniorProfileResponse> getSeniorProfile(@PathVariable Long seniorId) {
         SeniorProfileResponse seniorProfile = seniorInfoUseCase.getSeniorProfile(seniorId);
         return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_INFO.getMessage(), seniorProfile);
     }
 
     @GetMapping("/{seniorId}/times")
-    @Operation(summary = "대학원생 가능 시간 확인", description = "신청서 작성에서 가능 시간 작성시 노출 필요")
+    @Operation(summary = "대학원생 가능 시간 확인 | 토큰 필요", description = "신청서 작성에서 가능 시간 작성시 노출 필요")
     public ResponseDto<AvailableTimesResponse> getSeniorTimes(@PathVariable Long seniorId) {
         AvailableTimesResponse times = seniorInfoUseCase.getSeniorTimes(seniorId);
         return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_TIME.getMessage(), times);
@@ -122,8 +122,8 @@ public class SeniorController {
     @GetMapping("/field")
     @Operation(summary = "대학원생 필드 검색", description = "분야 (분야1,분야2 이런식으로, 다른분야 : others), 대학원 필수 (대학원1,대학원2 이런식으로, 다른학교 : others, 전체 : all), 페이지 선택 ")
     public ResponseDto<AllSeniorSearchResponse> getFieldSenior(@RequestParam String field,
-                                                                @RequestParam String postgradu,
-                                                                @RequestParam(required = false) Integer page) {
+                                                               @RequestParam String postgradu,
+                                                               @RequestParam(required = false) Integer page) {
         AllSeniorSearchResponse searchSenior = seniorInfoUseCase.getFieldSenior(field, postgradu, page);
         return ResponseDto.create(SENIOR_FIND.getCode(), GET_SENIOR_LIST_INFO.getMessage(), searchSenior);
     }

--- a/src/main/java/com/postgraduate/domain/wish/application/mapper/dto/res/WishResponse.java
+++ b/src/main/java/com/postgraduate/domain/wish/application/mapper/dto/res/WishResponse.java
@@ -15,8 +15,7 @@ public record WishResponse(
         Boolean marketingReceive,
         @NotNull
         Boolean matchingReceive,
-        @NotNull
         String major,
-        @NotNull
         String field
-) {}
+) {
+}

--- a/src/main/java/com/postgraduate/domain/wish/domain/repository/WishRepository.java
+++ b/src/main/java/com/postgraduate/domain/wish/domain/repository/WishRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface WishRepository extends JpaRepository<Wish, Long>, WishDslRepository {
     Optional<Wish> findByUser(User user);
+
+    Optional<Wish> findByWishIdAndMatchingReceiveIsTrue(Long wishId);
 }

--- a/src/main/java/com/postgraduate/domain/wish/domain/service/WishGetService.java
+++ b/src/main/java/com/postgraduate/domain/wish/domain/service/WishGetService.java
@@ -20,7 +20,7 @@ public class WishGetService {
     private final WishRepository wishRepository;
 
     public Wish byWishId(Long wishId) {
-        return wishRepository.findById(wishId).orElseThrow(WishNotFoundException::new);
+        return wishRepository.findByWishIdAndMatchingReceiveIsTrue(wishId).orElseThrow(WishNotFoundException::new);
     }
 
     public Optional<Wish> byUser(User user) {

--- a/src/main/java/com/postgraduate/domain/wish/exception/WishEmptyException.java
+++ b/src/main/java/com/postgraduate/domain/wish/exception/WishEmptyException.java
@@ -1,0 +1,12 @@
+package com.postgraduate.domain.wish.exception;
+
+import com.postgraduate.domain.admin.exception.SeniorException;
+
+import static com.postgraduate.domain.wish.presentation.constant.WishResponseCode.WISH_EMPTY;
+import static com.postgraduate.domain.wish.presentation.constant.WishResponseMessage.EMPTY_WISH;
+
+public class WishEmptyException extends SeniorException {
+    public WishEmptyException() {
+        super(EMPTY_WISH.getMessage(), WISH_EMPTY.getCode());
+    }
+}

--- a/src/main/java/com/postgraduate/domain/wish/presentation/constant/WishResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/wish/presentation/constant/WishResponseCode.java
@@ -12,6 +12,7 @@ public enum WishResponseCode {
     WISH_DELETE("WSH203"),
 
     WISH_NOT_FOUND("EX200"),
-    MATCHING_NOT_RECEIVE("EX201");
+    MATCHING_NOT_RECEIVE("EX201"),
+    WISH_EMPTY("EX202");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/wish/presentation/constant/WishResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/wish/presentation/constant/WishResponseMessage.java
@@ -10,7 +10,8 @@ public enum WishResponseMessage {
     GET_WISH_LIST_INFO("지원 리스트 조회에 성공하였습니다."),
 
     NOT_FOUND_WISH("지원을 찾을 수 없습니다."),
-    NOT_AGREE_MATCHING("매칭에 동의하지 않았습니다.");
+    NOT_AGREE_MATCHING("매칭에 동의하지 않았습니다."),
+    EMPTY_WISH("매칭 지원 정보가 없습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/postgraduate/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/postgraduate/global/config/security/SecurityConfig.java
@@ -54,6 +54,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers(PASS).permitAll()
                         .requestMatchers("/admin/**").hasAuthority(Role.ADMIN.name())
+                        .requestMatchers("/senior/field").permitAll()
+                        .requestMatchers("/senior/search").permitAll()
+                        .requestMatchers("/senior/**").authenticated()
                         .anyRequest().permitAll()
                 )
                 .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/postgraduate/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/postgraduate/global/config/security/SecurityConfig.java
@@ -52,12 +52,12 @@ public class SecurityConfig {
                 .logout(logout -> logout.disable());
         http
                 .authorizeHttpRequests((authorize) -> authorize
-                        .requestMatchers(PASS).permitAll()
-                        .requestMatchers("/admin/**").hasAuthority(Role.ADMIN.name())
-                        .requestMatchers("/senior/field").permitAll()
-                        .requestMatchers("/senior/search").permitAll()
-                        .requestMatchers("/senior/**").authenticated()
-                        .anyRequest().permitAll()
+                                .requestMatchers(PASS).permitAll()
+                                .requestMatchers("/admin/**").hasAuthority(Role.ADMIN.name())
+//                        .requestMatchers("/senior/field").permitAll()
+//                        .requestMatchers("/senior/search").permitAll()
+//                        .requestMatchers("/senior/**").authenticated()
+                                .anyRequest().permitAll()
                 )
                 .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling((exceptions) -> exceptions


### PR DESCRIPTION
## 🦝 PR 요약
+ 전체 점검 진행했습니다.
+ 충돌을 방지하기 위해 작업한 내용 먼저 머지 후, 노션에 점검사항 확인하면서 다른 브랜치에서 나머지 작업 하겠습니다.

## ✨ PR 상세 내용
+ 관리자에서 매칭 지원 정보를 기입하지 않은 [정보보기]가 아닌 [빈칸의 모달]을 보여주므로 지원 정보가 없다면 `null`을 반환하도록 했습니다.
+ 관리자에서 후배 멘토링 조회 시 선배 정보가 나오지 않는 오류를 해결했습니다.
+ 멘토링 취소 및 환불 기능을 추가했습니다. (환불의 경우 Payment 까지만)
+ 선배 상세 조회 시 로그인이 필요하므로 security에 권한 검사하도록 했습니다.
+ 멘토링 결제에서 멘토링 시간이 필요해 추가했습니다.


## 🚨 주의 사항


## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
