### PR TITLE
RAC-286 fix: 코드 통일

### DIFF
--- a/src/main/java/com/postgraduate/domain/account/domain/service/AccountSaveService.java
+++ b/src/main/java/com/postgraduate/domain/account/domain/service/AccountSaveService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 public class AccountSaveService {
     private final AccountRepository accountRepository;
 
-    public void saveAccount(Account account) {
+    public void save(Account account) {
         accountRepository.save(account);
     }
 }

--- a/src/main/java/com/postgraduate/domain/admin/application/usecase/MentoringManageByAdminUseCase.java
+++ b/src/main/java/com/postgraduate/domain/admin/application/usecase/MentoringManageByAdminUseCase.java
@@ -37,7 +37,7 @@ public class MentoringManageByAdminUseCase {
         List<MentoringInfo> mentoringInfos = mentorings.stream()
                 .map(AdminMapper::mapToSeniorMentoringInfo)
                 .toList();
-        User user = userGetService.getUser(userId);
+        User user = userGetService.byUserId(userId);
         UserMentoringInfo userMentoringInfo = AdminMapper.mapToUserMentoringInfo(user);
         return new MentoringManageResponse(mentoringInfos, userMentoringInfo);
     }

--- a/src/main/java/com/postgraduate/domain/admin/exception/SeniorNotWaitingException.java
+++ b/src/main/java/com/postgraduate/domain/admin/exception/SeniorNotWaitingException.java
@@ -3,8 +3,8 @@ package com.postgraduate.domain.admin.exception;
 import com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode;
 import com.postgraduate.domain.senior.presentation.constant.SeniorResponseMessage;
 
-public class SeniorNotWaitingException extends SeniorException{
+public class SeniorNotWaitingException extends SeniorException {
     public SeniorNotWaitingException() {
-        super(SeniorResponseMessage.NOT_WAITING_STATUS.getMessage(), SeniorResponseCode.NOT_WAITING_STATUS.getCode());
+        super(SeniorResponseMessage.NOT_WAITING_STATUS.getMessage(), SeniorResponseCode.STATUS_NOT_WAITING.getCode());
     }
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/dto/req/SeniorSignUpRequest.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/dto/req/SeniorSignUpRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record SeniorSignUpRequest(@NotNull Long socialId, @NotBlank String phoneNumber,
-                                  @Size(max = 6) @NotBlank String nickName,
+                                  @Size(max = 6, message = "6글자까지 입력 가능합니다.") @NotBlank String nickName,
                                   Boolean marketingReceive, @NotBlank String major, @NotBlank String postgradu,
                                   @NotBlank String professor, @NotBlank String lab, @NotBlank String field,
                                   @NotBlank String keyword, @NotBlank String certification) {

--- a/src/main/java/com/postgraduate/domain/auth/application/dto/req/SeniorSignUpRequest.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/dto/req/SeniorSignUpRequest.java
@@ -2,8 +2,10 @@ package com.postgraduate.domain.auth.application.dto.req;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
-public record SeniorSignUpRequest(@NotNull Long socialId, @NotBlank String phoneNumber, @NotBlank String nickName,
+public record SeniorSignUpRequest(@NotNull Long socialId, @NotBlank String phoneNumber,
+                                  @Size(max = 6) @NotBlank String nickName,
                                   Boolean marketingReceive, @NotBlank String major, @NotBlank String postgradu,
                                   @NotBlank String professor, @NotBlank String lab, @NotBlank String field,
                                   @NotBlank String keyword, @NotBlank String certification) {

--- a/src/main/java/com/postgraduate/domain/auth/application/dto/req/SeniorSignUpRequest.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/dto/req/SeniorSignUpRequest.java
@@ -1,8 +1,9 @@
 package com.postgraduate.domain.auth.application.dto.req;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
-public record SeniorSignUpRequest(Long socialId, @NotBlank String phoneNumber, @NotBlank String nickName,
+public record SeniorSignUpRequest(@NotNull Long socialId, @NotBlank String phoneNumber, @NotBlank String nickName,
                                   Boolean marketingReceive, @NotBlank String major, @NotBlank String postgradu,
                                   @NotBlank String professor, @NotBlank String lab, @NotBlank String field,
                                   @NotBlank String keyword, @NotBlank String certification) {

--- a/src/main/java/com/postgraduate/domain/auth/application/dto/req/SignUpRequest.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/dto/req/SignUpRequest.java
@@ -1,15 +1,20 @@
 package com.postgraduate.domain.auth.application.dto.req;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record SignUpRequest(
+        @NotNull
         Long socialId,
         @NotBlank
         String phoneNumber,
         @NotBlank
+        @Size(max = 6, message = "6글자까지 입력 가능합니다.")
         String nickName,
-        Boolean marketingReceive,
+        boolean marketingReceive,
         String major,
         String field,
-        Boolean matchingReceive
-) { }
+        boolean matchingReceive
+) {
+}

--- a/src/main/java/com/postgraduate/domain/auth/application/dto/req/UserChangeRequest.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/dto/req/UserChangeRequest.java
@@ -2,5 +2,5 @@ package com.postgraduate.domain.auth.application.dto.req;
 
 public record UserChangeRequest(String major,
                                 String field,
-                                Boolean matchingReceive) {
+                                boolean matchingReceive) {
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
@@ -7,7 +7,6 @@ import com.postgraduate.domain.auth.application.dto.req.UserChangeRequest;
 import com.postgraduate.domain.salary.application.mapper.SalaryMapper;
 import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.salary.domain.service.SalarySaveService;
-import com.postgraduate.domain.salary.util.SalaryUtil;
 import com.postgraduate.domain.senior.application.mapper.SeniorMapper;
 import com.postgraduate.domain.senior.application.utils.SeniorUtils;
 import com.postgraduate.domain.senior.domain.entity.Senior;
@@ -45,8 +44,8 @@ public class SignUpUseCase {
         userUtils.checkPhoneNumber(request.phoneNumber());
         User user = UserMapper.mapToUser(request);
         Wish wish = WishMapper.mapToWish(user, request);
-        wishSaveService.saveWish(wish);
-        userSaveService.saveUser(user);
+        wishSaveService.save(wish);
+        userSaveService.save(user);
         return user;
     }
 
@@ -54,11 +53,11 @@ public class SignUpUseCase {
         seniorUtils.checkKeyword(request.keyword());
         userUtils.checkPhoneNumber(request.phoneNumber());
         User user = UserMapper.mapToUser(request);
-        userSaveService.saveUser(user);
+        userSaveService.save(user);
         Senior senior = SeniorMapper.mapToSenior(user, request);
         seniorSaveService.saveSenior(senior);
         Salary salary = SalaryMapper.mapToSalary(senior, getSalaryDate());
-        salarySaveService.saveSalary(salary);
+        salarySaveService.save(salary);
         return senior.getUser();
     }
 
@@ -66,15 +65,15 @@ public class SignUpUseCase {
         seniorUtils.checkKeyword(changeRequest.keyword());
         Senior senior = SeniorMapper.mapToSenior(user, changeRequest); //todo : 예외 처리
         seniorSaveService.saveSenior(senior);
-        user = userGetService.getUser(user.getUserId());
+        user = userGetService.byUserId(user.getUserId());
         userUpdateService.updateRole(user, Role.SENIOR);
         Salary salary = SalaryMapper.mapToSalary(senior, getSalaryDate());
-        salarySaveService.saveSalary(salary);
+        salarySaveService.save(salary);
         return user;
     }
 
     public void changeUser(User user, UserChangeRequest changeRequest) {
         Wish wish = WishMapper.mapToWish(user, changeRequest);
-        wishSaveService.saveWish(wish);
+        wishSaveService.save(wish);
     }
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignOutUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignOutUseCase.java
@@ -34,7 +34,7 @@ public class KakaoSignOutUseCase implements SignOutUseCase {
     @Override
     public void signOut(Long userId) {
         try {
-            User user = userGetService.getUser(userId);
+            User user = userGetService.byUserId(userId);
             MultiValueMap<String, String> requestBody = getRequestBody(user.getSocialId());
             webClient.post()
                     .uri(KAKAO_UNLINK_URI)

--- a/src/main/java/com/postgraduate/domain/auth/exception/OauthException.java
+++ b/src/main/java/com/postgraduate/domain/auth/exception/OauthException.java
@@ -1,10 +1,10 @@
 package com.postgraduate.domain.auth.exception;
 
-import static com.postgraduate.domain.auth.presentation.constant.AuthResponseCode.NONE_PROVIDER;
-import static com.postgraduate.domain.auth.presentation.constant.AuthResponseMessage.PROVIDER_NONE;
+import static com.postgraduate.domain.auth.presentation.constant.AuthResponseCode.PROVIDER_NOT_FOUND;
+import static com.postgraduate.domain.auth.presentation.constant.AuthResponseMessage.NOT_FOUND_PROVIDER;
 
-public class OauthException extends AuthException{
+public class OauthException extends AuthException {
     public OauthException() {
-        super(PROVIDER_NONE.getMessage(), NONE_PROVIDER.getCode());
+        super(NOT_FOUND_PROVIDER.getMessage(), PROVIDER_NOT_FOUND.getCode());
     }
 }

--- a/src/main/java/com/postgraduate/domain/auth/presentation/constant/AuthResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/constant/AuthResponseCode.java
@@ -17,6 +17,6 @@ public enum AuthResponseCode {
     AUTH_INVALID_KAKAO("EX901"),
     AUTH_KAKAO_CODE("EX902"),
     AUTH_FAILED("EX903"),
-    NONE_PROVIDER("EX904");
+    PROVIDER_NOT_FOUND("EX904");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/auth/presentation/constant/AuthResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/constant/AuthResponseMessage.java
@@ -16,6 +16,6 @@ public enum AuthResponseMessage {
     KAKAO_INVALID("카카오 정보가 유효하지 않습니다."),
     KAKAO_CODE("카카오 코드가 유효하지 않습니다."),
     FAILED_AUTH("사용자 인증에 실패했습니다."),
-    PROVIDER_NONE("PROVIDER가 없습니다.");
+    NOT_FOUND_PROVIDER("PROVIDER가 없습니다.");
     private final String message;
 }

--- a/src/main/java/com/postgraduate/domain/available/exception/EmptyAvailableException.java
+++ b/src/main/java/com/postgraduate/domain/available/exception/EmptyAvailableException.java
@@ -1,10 +1,10 @@
 package com.postgraduate.domain.available.exception;
 
-import com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode;
-import com.postgraduate.domain.senior.presentation.constant.SeniorResponseMessage;
+import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode.TIME_EMPTY;
+import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseMessage.EMPTY_TIME;
 
-public class EmptyAvailableException extends AvailableException{
+public class EmptyAvailableException extends AvailableException {
     public EmptyAvailableException() {
-        super(SeniorResponseMessage.EMPTY_TIME.getMessage(), SeniorResponseCode.EMPTY_TIME.getCode());
+        super(EMPTY_TIME.getMessage(), TIME_EMPTY.getCode());
     }
 }

--- a/src/main/java/com/postgraduate/domain/image/application/dto/req/PreSignedUrlRequest.java
+++ b/src/main/java/com/postgraduate/domain/image/application/dto/req/PreSignedUrlRequest.java
@@ -1,12 +1,6 @@
 package com.postgraduate.domain.image.application.dto.req;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
-public class PreSignedUrlRequest {
-    private String fileName;
+public record PreSignedUrlRequest(@NotBlank String fileName) {
 }

--- a/src/main/java/com/postgraduate/domain/image/application/dto/res/PreSignedUrlResponse.java
+++ b/src/main/java/com/postgraduate/domain/image/application/dto/res/PreSignedUrlResponse.java
@@ -1,14 +1,4 @@
 package com.postgraduate.domain.image.application.dto.res;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Builder
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class PreSignedUrlResponse {
-    private String preSignedUrl;
+public record PreSignedUrlResponse(String preSignedUrl) {
 }

--- a/src/main/java/com/postgraduate/domain/image/application/usecase/PreSignedUseCase.java
+++ b/src/main/java/com/postgraduate/domain/image/application/usecase/PreSignedUseCase.java
@@ -13,16 +13,16 @@ public class PreSignedUseCase {
     private final S3Service s3Service;
 
     public PreSignedUrlResponse getProfileUrl(PreSignedUrlRequest preSignedUrlRequest) {
-        if (preSignedUrlRequest.getFileName().isEmpty())
+        if (preSignedUrlRequest.fileName().isEmpty())
             throw new EmptyFileException();
-        String preSignedUrl = s3Service.getProfilePreSignedUrl(preSignedUrlRequest.getFileName());
+        String preSignedUrl = s3Service.getProfilePreSignedUrl(preSignedUrlRequest.fileName());
         return new PreSignedUrlResponse(preSignedUrl);
     }
 
     public PreSignedUrlResponse getCertificationUrl(PreSignedUrlRequest preSignedUrlRequest) {
-        if (preSignedUrlRequest.getFileName().isEmpty())
+        if (preSignedUrlRequest.fileName().isEmpty())
             throw new EmptyFileException();
-        String preSignedUrl = s3Service.getCertificationPreSignedUrl(preSignedUrlRequest.getFileName());
+        String preSignedUrl = s3Service.getCertificationPreSignedUrl(preSignedUrlRequest.fileName());
         return new PreSignedUrlResponse(preSignedUrl);
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/application/dto/req/MentoringApplyRequest.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/dto/req/MentoringApplyRequest.java
@@ -1,8 +1,10 @@
 package com.postgraduate.domain.mentoring.application.dto.req;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record MentoringApplyRequest(
+        @NotNull
         Long seniorId,
         @NotBlank
         String topic,
@@ -10,4 +12,5 @@ public record MentoringApplyRequest(
         String question,
         @NotBlank
         String date
-) { }
+) {
+}

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseCase.java
@@ -75,7 +75,7 @@ public class MentoringManageUseCase {
         if (mentoring.getStatus() != WAITING)
             throw new MentoringNotWaitingException();
         Refuse refuse = RefuseMapper.mapToRefuse(mentoring, request);
-        refuseSaveService.saveRefuse(refuse);
+        refuseSaveService.save(refuse);
         mentoringUpdateService.updateStatus(mentoring, REFUSE);
     }
 
@@ -104,7 +104,7 @@ public class MentoringManageUseCase {
         waitingMentorings.forEach(mentoring -> {
             mentoringUpdateService.updateStatus(mentoring, CANCEL);
             Refuse refuse = RefuseMapper.mapToRefuse(mentoring);
-            refuseSaveService.saveRefuse(refuse);
+            refuseSaveService.save(refuse);
             //TODO : 알림 보내거나 나머지 작업
         });
     }

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCase.java
@@ -5,7 +5,6 @@ import com.postgraduate.domain.mentoring.application.dto.ExpectedSeniorMentoring
 import com.postgraduate.domain.mentoring.application.dto.WaitingSeniorMentoringInfo;
 import com.postgraduate.domain.mentoring.application.dto.res.SeniorMentoringDetailResponse;
 import com.postgraduate.domain.mentoring.application.dto.res.SeniorMentoringResponse;
-import com.postgraduate.domain.mentoring.application.mapper.MentoringMapper;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.mentoring.domain.entity.constant.Status;
 import com.postgraduate.domain.mentoring.domain.service.MentoringGetService;
@@ -18,13 +17,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static com.postgraduate.domain.mentoring.application.mapper.MentoringMapper.*;
-import static com.postgraduate.domain.mentoring.domain.entity.constant.Status.*;
+import static com.postgraduate.domain.mentoring.domain.entity.constant.Status.EXPECTED;
+import static com.postgraduate.domain.mentoring.domain.entity.constant.Status.WAITING;
 import static java.time.Duration.between;
 
 @Service
@@ -80,11 +78,11 @@ public class MentoringSeniorInfoUseCase {
 
     private List<Mentoring> getMentorings(User user, Status status) {
         Senior senior = seniorGetService.byUser(user);
-        return mentoringGetService.mentoringBySenior(senior, status);
+        return mentoringGetService.bySenior(senior, status);
     }
 
     private List<DoneSeniorMentoringInfo> getDoneMentorings(User user) {
         Senior senior = seniorGetService.byUser(user);
-        return mentoringGetService.mentoringBySenior(senior);
+        return mentoringGetService.bySenior(senior);
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCase.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.postgraduate.domain.mentoring.application.mapper.MentoringMapper.*;
+import static com.postgraduate.domain.mentoring.application.mapper.MentoringMapper.mapToAppliedDetailInfo;
 import static com.postgraduate.domain.mentoring.domain.entity.constant.Status.*;
 
 @Service
@@ -35,7 +35,7 @@ public class MentoringUserInfoUseCase {
     }
 
     public AppliedMentoringResponse getWaiting(User user) {
-        List<Mentoring> mentorings = mentoringGetService.mentoringByUser(user, WAITING);
+        List<Mentoring> mentorings = mentoringGetService.byUser(user, WAITING);
         List<WaitingMentoringInfo> waitingMentoringInfos = mentorings.stream()
                 .map(MentoringMapper::mapToWaitingInfo)
                 .toList();
@@ -43,7 +43,7 @@ public class MentoringUserInfoUseCase {
     }
 
     public AppliedMentoringResponse getExpected(User user) {
-        List<Mentoring> mentorings = mentoringGetService.mentoringByUser(user, EXPECTED);
+        List<Mentoring> mentorings = mentoringGetService.byUser(user, EXPECTED);
         List<ExpectedMentoringInfo> expectedMentoringInfos = mentorings.stream()
                 .map(MentoringMapper::mapToExpectedInfo)
                 .toList();
@@ -51,7 +51,7 @@ public class MentoringUserInfoUseCase {
     }
 
     public AppliedMentoringResponse getDone(User user) {
-        List<Mentoring> mentorings = mentoringGetService.mentoringByUser(user, DONE);
+        List<Mentoring> mentorings = mentoringGetService.byUser(user, DONE);
         List<DoneMentoringInfo> doneMentoringInfos = mentorings.stream()
                 .map(MentoringMapper::mapToDoneInfo)
                 .toList();

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
@@ -18,15 +18,15 @@ import java.util.List;
 public class MentoringGetService {
     private final MentoringRepository mentoringRepository;
 
-    public List<Mentoring> mentoringByUser(User user, Status status) {
+    public List<Mentoring> byUser(User user, Status status) {
         return mentoringRepository.findAllByUserAndStatus(user, status);
     }
 
-    public List<Mentoring> mentoringBySenior(Senior senior, Status status) {
+    public List<Mentoring> bySenior(Senior senior, Status status) {
         return mentoringRepository.findAllBySeniorAndStatus(senior, status);
     }
 
-    public List<DoneSeniorMentoringInfo> mentoringBySenior(Senior senior) {
+    public List<DoneSeniorMentoringInfo> bySenior(Senior senior) {
         return mentoringRepository.findAllBySeniorAndDone(senior);
     }
 

--- a/src/main/java/com/postgraduate/domain/refuse/domain/service/RefuseSaveService.java
+++ b/src/main/java/com/postgraduate/domain/refuse/domain/service/RefuseSaveService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 public class RefuseSaveService {
     private final RefuseRepository refuseRepository;
 
-    public void saveRefuse(Refuse refuse) {
+    public void save(Refuse refuse) {
         refuseRepository.save(refuse);
     }
 }

--- a/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryManageUseCase.java
@@ -35,7 +35,7 @@ public class SalaryManageUseCase {
         LocalDate salaryDate = SalaryUtil.getSalaryDate();
         seniorAndAccounts.forEach(seniorAndAccount -> {
             Salary salary = SalaryMapper.mapToSalary(seniorAndAccount.senior(), salaryDate, seniorAndAccount.account());
-            salarySaveService.saveSalary(salary);
+            salarySaveService.save(salary);
         });
     }
 }

--- a/src/main/java/com/postgraduate/domain/salary/domain/service/SalarySaveService.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/service/SalarySaveService.java
@@ -10,8 +10,7 @@ import org.springframework.stereotype.Service;
 public class SalarySaveService {
     private final SalaryRepository salaryRepository;
 
-    public Salary saveSalary(Salary salary) {
-        Salary save = salaryRepository.save(salary);
-        return save;
+    public Salary save(Salary salary) {
+        return salaryRepository.save(salary);
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
@@ -71,7 +71,7 @@ public class SeniorManageUseCase {
     public void saveAccount(User user, SeniorAccountRequest accountRequest) {
         Senior senior = seniorGetService.byUser(user);
         String accountNumber = encryptorUtils.encryptData(accountRequest.accountNumber());
-        accountSaveService.saveAccount(mapToAccount(senior, accountRequest, accountNumber));
+        accountSaveService.save(mapToAccount(senior, accountRequest, accountNumber));
         updateSalaryAccount(senior, accountRequest.bank(), accountNumber, accountRequest.accountHolder());
     }
 
@@ -89,7 +89,7 @@ public class SeniorManageUseCase {
     public void updateSeniorMyPageUserAccount(User user, SeniorMyPageUserAccountRequest myPageUserAccountRequest) {
         userUtils.checkPhoneNumber(myPageUserAccountRequest.phoneNumber());
         Senior senior = seniorGetService.byUser(user);
-        user = userGetService.getUser(user.getUserId());
+        user = userGetService.byUserId(user.getUserId());
         userUpdateService.updateSeniorUserAccount(user, myPageUserAccountRequest);
 
         Optional<Account> optionalAccount = accountGetService.bySenior(senior);
@@ -111,7 +111,7 @@ public class SeniorManageUseCase {
         }
         String accountNumber = encryptorUtils.encryptData(myPageUserAccountRequest.accountNumber());
         Account account = mapToAccount(senior, myPageUserAccountRequest, accountNumber);
-        accountSaveService.saveAccount(account);
+        accountSaveService.save(account);
         updateSalaryAccount(senior, myPageUserAccountRequest.bank(), accountNumber, myPageUserAccountRequest.accountHolder());
     }
 

--- a/src/main/java/com/postgraduate/domain/senior/exception/NoneAccountException.java
+++ b/src/main/java/com/postgraduate/domain/senior/exception/NoneAccountException.java
@@ -6,6 +6,6 @@ import com.postgraduate.global.exception.ApplicationException;
 
 public class NoneAccountException extends ApplicationException {
     public NoneAccountException() {
-        super(SeniorResponseMessage.NONE_ACCOUNT.getMessage(), SeniorResponseCode.NONE_ACCOUNT.getCode());
+        super(SeniorResponseMessage.NOT_FOUND_ACCOUNT.getMessage(), SeniorResponseCode.ACCOUNT_NOT_FOUND.getCode());
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/exception/NoneProfileException.java
+++ b/src/main/java/com/postgraduate/domain/senior/exception/NoneProfileException.java
@@ -6,6 +6,6 @@ import com.postgraduate.global.exception.ApplicationException;
 
 public class NoneProfileException extends ApplicationException {
     public NoneProfileException() {
-        super(SeniorResponseMessage.NONE_PROFILE.getMessage(), SeniorResponseCode.NONE_PROFILE.getCode());
+        super(SeniorResponseMessage.NOT_FOUND_PROFILE.getMessage(), SeniorResponseCode.PROFILE_NOT_FOUND.getCode());
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/exception/NoneSeniorException.java
+++ b/src/main/java/com/postgraduate/domain/senior/exception/NoneSeniorException.java
@@ -3,8 +3,8 @@ package com.postgraduate.domain.senior.exception;
 import com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode;
 import com.postgraduate.domain.senior.presentation.constant.SeniorResponseMessage;
 
-public class NoneSeniorException extends SeniorException{
+public class NoneSeniorException extends SeniorException {
     public NoneSeniorException() {
-        super(SeniorResponseMessage.NONE_SENIOR.getMessage(), SeniorResponseCode.NONE_SENIOR.getCode());
+        super(SeniorResponseMessage.NOT_FOUND_SENIOR.getMessage(), SeniorResponseCode.SENIOR_NOT_FOUND.getCode());
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -93,7 +93,7 @@ public class SeniorController {
     public ResponseDto updateSeniorUserAccount(@AuthenticationPrincipal User user,
                                                @RequestBody @Valid SeniorMyPageUserAccountRequest myPageUserAccountRequest) {
         seniorManageUseCase.updateSeniorMyPageUserAccount(user, myPageUserAccountRequest);
-        return ResponseDto.create(SENIOR_UPDATE.getCode(), UPDATE_MYPAGE_ACCOOUNT.getMessage());
+        return ResponseDto.create(SENIOR_UPDATE.getCode(), UPDATE_MYPAGE_ACCOUNT.getMessage());
     }
 
     @GetMapping("/{seniorId}")

--- a/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseCode.java
@@ -15,7 +15,7 @@ public enum SeniorResponseCode {
     ACCOUNT_NOT_FOUND("EX401"),
     STATUS_NOT_WAITING("EX402"),
     INVALID_KEYWORD("EX402"),
-    EMPTY_TIME("EX403"),
+    TIME_EMPTY("EX403"),
     INVALID_DAY("EX404"),
     PROFILE_NOT_FOUND("EX405"),
     ;

--- a/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseCode.java
@@ -11,13 +11,13 @@ public enum SeniorResponseCode {
     SENIOR_CREATE("SNR202"),
     SENIOR_DELETE("SNR203"),
 
-    NONE_SENIOR("EX400"),
-    NONE_ACCOUNT("EX401"),
-    NOT_WAITING_STATUS("EX402"),
+    SENIOR_NOT_FOUND("EX400"),
+    ACCOUNT_NOT_FOUND("EX401"),
+    STATUS_NOT_WAITING("EX402"),
     INVALID_KEYWORD("EX402"),
     EMPTY_TIME("EX403"),
     INVALID_DAY("EX404"),
-    NONE_PROFILE("EX405"),
+    PROFILE_NOT_FOUND("EX405"),
     ;
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseCode.java
@@ -14,10 +14,10 @@ public enum SeniorResponseCode {
     SENIOR_NOT_FOUND("EX400"),
     ACCOUNT_NOT_FOUND("EX401"),
     STATUS_NOT_WAITING("EX402"),
-    INVALID_KEYWORD("EX402"),
     TIME_EMPTY("EX403"),
     INVALID_DAY("EX404"),
     PROFILE_NOT_FOUND("EX405"),
+    INVALID_KEYWORD("EX406"),
     ;
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseMessage.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/constant/SeniorResponseMessage.java
@@ -11,7 +11,7 @@ public enum SeniorResponseMessage {
     UPDATE_ACCOUNT("대학원생 계좌 수정에 성공하였습니다"),
     CREATE_ACCOUNT("대학원생 계좌 등록에 성공하였습니다"),
     UPDATE_MYPAGE_PROFILE("대학원생 마이페이지 프로필 수정에 성공하였습니다"),
-    UPDATE_MYPAGE_ACCOOUNT("대학원생 마이페이지 계정 수정에 성공하였습니다"),
+    UPDATE_MYPAGE_ACCOUNT("대학원생 마이페이지 계정 수정에 성공하였습니다"),
     GET_SENIOR_INFO("대학원생 정보 조회에 성공하였습니다"),
     GET_SENIOR_TIME("대학원생 가능 시간 조회에 성공하였습니다"),
     GET_SENIOR_MYPAGE_PROFILE("대학원생 마이페이지 프로필 조회에 성공하였습니다"),
@@ -23,13 +23,13 @@ public enum SeniorResponseMessage {
     UPDATE_STATUS("대학원생 승인 요청 응답에 성공하였습니다"),
     GET_USER_CHECK("후배 변경 가능 여부 확인에 성공하였습니다"),
 
-    NONE_SENIOR("등록된 멘토가 없습니다."),
-    NONE_ACCOUNT("계좌가 없습니다."),
+    NOT_FOUND_SENIOR("등록된 멘토가 없습니다."),
+    NOT_FOUND_ACCOUNT("계좌가 없습니다."),
     INVALID_KEYWORD("키워드가 잘못되었습니다."),
     NOT_WAITING_STATUS("승인대기 상태의 선배가 아닙니다."),
     EMPTY_TIME("가능 시간이 비었습니다."),
     INVALID_DAY("잘못된 요일입니다."),
-    NONE_PROFILE("등록한 프로필이 없습니다."),
+    NOT_FOUND_PROFILE("등록한 프로필이 없습니다."),
     ;
 
     private final String message;

--- a/src/main/java/com/postgraduate/domain/user/application/usecase/UserManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/user/application/usecase/UserManageUseCase.java
@@ -19,7 +19,7 @@ public class UserManageUseCase {
 
     public void updateInfo(User user, UserInfoRequest userInfoRequest) {
         userUtils.checkPhoneNumber(userInfoRequest.phoneNumber());
-        user = userGetService.getUser(user.getUserId());
+        user = userGetService.byUserId(user.getUserId());
         userUpdateService.updateInfo(user, userInfoRequest);
     }
 

--- a/src/main/java/com/postgraduate/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/service/UserGetService.java
@@ -1,8 +1,8 @@
 package com.postgraduate.domain.user.domain.service;
 
-import com.postgraduate.domain.user.exception.UserNotFoundException;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.repository.UserRepository;
+import com.postgraduate.domain.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,9 +14,8 @@ import java.util.Optional;
 public class UserGetService {
     private final UserRepository userRepository;
 
-    public User getUser(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-        return user;
+    public User byUserId(Long userId) {
+        return userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
     }
 
     public User bySocialId(Long socialId) {
@@ -26,6 +25,7 @@ public class UserGetService {
     public Optional<User> byNickName(String nickName) {
         return userRepository.findByNickName(nickName);
     }
+
     public List<User> all() {
         return userRepository.findAll();
     }

--- a/src/main/java/com/postgraduate/domain/user/domain/service/UserSaveService.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/service/UserSaveService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 public class UserSaveService {
     private final UserRepository userRepository;
 
-    public void saveUser(User user) {
+    public void save(User user) {
         userRepository.save(user);
     }
 }

--- a/src/main/java/com/postgraduate/domain/user/exception/DeletedUserException.java
+++ b/src/main/java/com/postgraduate/domain/user/exception/DeletedUserException.java
@@ -3,8 +3,8 @@ package com.postgraduate.domain.user.exception;
 import com.postgraduate.domain.user.presentation.constant.UserResponseCode;
 import com.postgraduate.domain.user.presentation.constant.UserResponseMessage;
 
-public class DeletedUserException extends UserException{
+public class DeletedUserException extends UserException {
     public DeletedUserException() {
-        super(UserResponseMessage.DELETED_USER.getMessage(), UserResponseCode.DELETED_USER.getCode());
+        super(UserResponseMessage.DELETED_USER.getMessage(), UserResponseCode.USER_DELETED.getCode());
     }
 }

--- a/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/user/presentation/constant/UserResponseCode.java
@@ -12,7 +12,7 @@ public enum UserResponseCode {
     USER_DELETE("UR203"),
 
     USER_NOT_FOUND("EX300"),
-    DELETED_USER("EX301"),
+    USER_DELETED("EX301"),
     INVALID_PHONE_NUMBER("EX302");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/domain/wish/domain/service/WishSaveService.java
+++ b/src/main/java/com/postgraduate/domain/wish/domain/service/WishSaveService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 public class WishSaveService {
     private final WishRepository wishRepository;
 
-    public void saveWish(Wish wish) {
+    public void save(Wish wish) {
         wishRepository.save(wish);
     }
 }

--- a/src/main/java/com/postgraduate/domain/wish/exception/MatchingNotReceiveException.java
+++ b/src/main/java/com/postgraduate/domain/wish/exception/MatchingNotReceiveException.java
@@ -2,11 +2,11 @@ package com.postgraduate.domain.wish.exception;
 
 import com.postgraduate.domain.salary.exception.SalaryException;
 
-import static com.postgraduate.domain.wish.presentation.constant.WishResponseCode.MATCHING_NOT_RECEIVE;
+import static com.postgraduate.domain.wish.presentation.constant.WishResponseCode.MATCHING_NOT_AGREE;
 import static com.postgraduate.domain.wish.presentation.constant.WishResponseMessage.NOT_AGREE_MATCHING;
 
 public class MatchingNotReceiveException extends SalaryException {
     public MatchingNotReceiveException() {
-        super(NOT_AGREE_MATCHING.getMessage(), MATCHING_NOT_RECEIVE.getCode());
+        super(NOT_AGREE_MATCHING.getMessage(), MATCHING_NOT_AGREE.getCode());
     }
 }

--- a/src/main/java/com/postgraduate/domain/wish/presentation/constant/WishResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/wish/presentation/constant/WishResponseCode.java
@@ -12,7 +12,7 @@ public enum WishResponseCode {
     WISH_DELETE("WSH203"),
 
     WISH_NOT_FOUND("EX200"),
-    MATCHING_NOT_RECEIVE("EX201"),
+    MATCHING_NOT_AGREE("EX201"),
     WISH_EMPTY("EX202");
     private final String code;
 }

--- a/src/main/java/com/postgraduate/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/postgraduate/global/config/security/SecurityConfig.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
@@ -52,12 +53,39 @@ public class SecurityConfig {
                 .logout(logout -> logout.disable());
         http
                 .authorizeHttpRequests((authorize) -> authorize
-                                .requestMatchers(PASS).permitAll()
-                                .requestMatchers("/admin/**").hasAuthority(Role.ADMIN.name())
-//                        .requestMatchers("/senior/field").permitAll()
-//                        .requestMatchers("/senior/search").permitAll()
-//                        .requestMatchers("/senior/**").authenticated()
-                                .anyRequest().permitAll()
+                        .requestMatchers(PASS).permitAll()
+                        .requestMatchers("/admin/**").hasAuthority(Role.ADMIN.name())
+
+                        .requestMatchers(HttpMethod.PATCH, "/senior/**").hasAuthority(Role.SENIOR.name())
+                        .requestMatchers(HttpMethod.POST, "/senior/**").hasAuthority(Role.SENIOR.name())
+                        .requestMatchers("/senior/me/**").hasAuthority(Role.SENIOR.name())
+                        .requestMatchers("/senior/search").permitAll()
+                        .requestMatchers("/senior/field").permitAll()
+                        .requestMatchers("/senior/all").permitAll()
+                        .requestMatchers("/senior/{seniorId}").authenticated()
+                        .requestMatchers("/senior/{seniorId}/times").hasAuthority(Role.USER.name())
+                        .requestMatchers("/senior/{seniorId}/profile").hasAuthority(Role.USER.name())
+                        .requestMatchers("/senior/**").hasAuthority(Role.SENIOR.name())
+
+                        .requestMatchers("/user/nickname").permitAll()
+                        .requestMatchers("/user/**").hasAuthority(Role.USER.name())
+
+                        .requestMatchers("/image/upload/profile").authenticated()
+
+                        .requestMatchers("/mentoring/applying").hasAuthority(Role.USER.name())
+                        .requestMatchers("/mentoring/me/**").hasAuthority(Role.USER.name())
+                        .requestMatchers("/mentoring/senior/**").hasAuthority(Role.SENIOR.name())
+
+                        .requestMatchers("/salary/**").hasAuthority(Role.SENIOR.name())
+
+                        .requestMatchers("/auth/user/token").hasAuthority(Role.SENIOR.name())
+                        .requestMatchers("/auth/user/change").hasAuthority(Role.SENIOR.name())
+                        .requestMatchers("/auth/senior/token").hasAuthority(Role.USER.name())
+                        .requestMatchers("/auth/senior/change").hasAuthority(Role.USER.name())
+                        .requestMatchers("/auth/refresh").authenticated()
+                        .requestMatchers("/auth/logout").authenticated()
+
+                        .anyRequest().permitAll()
                 )
                 .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling((exceptions) -> exceptions

--- a/src/main/java/com/postgraduate/global/config/security/jwt/filter/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/postgraduate/global/config/security/jwt/filter/CustomAccessDeniedHandler.java
@@ -26,7 +26,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
-        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setStatus(HttpStatus.OK.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
         logService.save(new LogRequest(CustomAccessDeniedHandler.class.getSimpleName(), PERMISSION_DENIED.getMessage()));

--- a/src/main/java/com/postgraduate/global/config/security/jwt/filter/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/postgraduate/global/config/security/jwt/filter/CustomAuthenticationEntryPoint.java
@@ -27,7 +27,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setStatus(HttpStatus.OK.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
         logService.save(new LogRequest(CustomAuthenticationEntryPoint.class.getSimpleName(), FAILED_AUTH.getMessage()));

--- a/src/main/java/com/postgraduate/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/postgraduate/global/exception/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ package com.postgraduate.global.exception;
 import com.postgraduate.global.dto.ErrorResponse;
 import com.postgraduate.global.dto.ResponseDto;
 import com.postgraduate.global.exception.constant.ErrorCode;
-import com.postgraduate.global.exception.constant.ErrorMessage;
 import com.postgraduate.global.logging.dto.LogRequest;
 import com.postgraduate.global.logging.service.LogService;
 import lombok.RequiredArgsConstructor;
@@ -20,15 +19,16 @@ import java.io.IOException;
 public class GlobalExceptionHandler {
     private final LogService logService;
     private static final String LOG_FORMAT = "Code : {}, Message : {}";
+
     @ExceptionHandler(ApplicationException.class)
     public ResponseDto<ErrorResponse> handleApplicationException(ApplicationException ex) {
         return ResponseDto.create(ex.getErrorCode(), ex.getMessage());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseDto<ErrorResponse> handleArgumentValidException() throws IOException {
-        logService.save(new LogRequest("@Valid", ErrorMessage.VALID_BLANK.getMessage()));
+    public ResponseDto<ErrorResponse> handleArgumentValidException(MethodArgumentNotValidException ex) throws IOException {
+        logService.save(new LogRequest("@Valid", ex.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
         log.error(LOG_FORMAT, "@Valid Error", "MethodArgumentNotValidException");
-        return ResponseDto.create(ErrorCode.VALID_BLANK.getCode(), ErrorMessage.VALID_BLANK.getMessage());
+        return ResponseDto.create(ErrorCode.VALID_BLANK.getCode(), ex.getBindingResult().getAllErrors().get(0).getDefaultMessage());
     }
 }

--- a/src/test/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCaseTest.java
@@ -3,7 +3,6 @@ package com.postgraduate.domain.auth.application.usecase.oauth;
 import com.postgraduate.domain.auth.application.dto.req.SeniorChangeRequest;
 import com.postgraduate.domain.auth.application.dto.req.SeniorSignUpRequest;
 import com.postgraduate.domain.auth.application.dto.req.SignUpRequest;
-import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.salary.domain.service.SalarySaveService;
 import com.postgraduate.domain.senior.application.utils.SeniorUtils;
 import com.postgraduate.domain.senior.domain.entity.Info;
@@ -24,9 +23,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -96,9 +92,9 @@ class SignUpUseCaseTest {
         assertThat(saveUser.getRole())
                 .isEqualTo(USER);
         verify(wishSaveService, times(1))
-                .saveWish(any(Wish.class));
+                .save(any(Wish.class));
         verify(userSaveService, times(1))
-                .saveUser(any(User.class));
+                .save(any(User.class));
     }
 
     @Test
@@ -126,7 +122,7 @@ class SignUpUseCaseTest {
         assertThat(saveUser.getRole())
                 .isEqualTo(SENIOR);
         verify(userSaveService, times(1))
-                .saveUser(any(User.class));
+                .save(any(User.class));
         verify(seniorSaveService, times(1))
                 .saveSenior(any(Senior.class));
     }
@@ -153,7 +149,7 @@ class SignUpUseCaseTest {
                 info.getLab(), info.getField(), info.getKeyword(),
                 senior.getCertification());
 
-        given(userGetService.getUser(user.getUserId()))
+        given(userGetService.byUserId(user.getUserId()))
                 .willReturn(user);
 
         signUpUseCase.changeSenior(user, seniorChangeRequest);

--- a/src/test/java/com/postgraduate/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/postgraduate/domain/auth/presentation/AuthControllerTest.java
@@ -5,8 +5,6 @@ import com.postgraduate.IntegrationTest;
 import com.postgraduate.domain.auth.application.dto.req.*;
 import com.postgraduate.domain.auth.application.dto.res.KakaoUserInfoResponse;
 import com.postgraduate.domain.auth.application.usecase.oauth.kakao.KakaoAccessTokenUseCase;
-import com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode;
-import com.postgraduate.domain.senior.presentation.constant.SeniorResponseMessage;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.domain.user.domain.repository.UserRepository;
 import com.postgraduate.domain.wish.domain.entity.Wish;
@@ -32,7 +30,9 @@ import java.util.Optional;
 import static com.postgraduate.domain.auth.presentation.constant.AuthResponseCode.*;
 import static com.postgraduate.domain.auth.presentation.constant.AuthResponseMessage.*;
 import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode.SENIOR_CREATE;
+import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseCode.SENIOR_NOT_FOUND;
 import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseMessage.CREATE_SENIOR;
+import static com.postgraduate.domain.senior.presentation.constant.SeniorResponseMessage.NOT_FOUND_SENIOR;
 import static com.postgraduate.domain.user.domain.entity.constant.Role.SENIOR;
 import static com.postgraduate.domain.user.domain.entity.constant.Role.USER;
 import static com.postgraduate.domain.user.presentation.constant.UserResponseCode.USER_NOT_FOUND;
@@ -339,8 +339,8 @@ class AuthControllerTest extends IntegrationTest {
         mvc.perform(post("/auth/senior/token")
                         .header(AUTHORIZATION, BEARER + token))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(SeniorResponseCode.NONE_SENIOR.getCode()))
-                .andExpect(jsonPath("$.message").value(SeniorResponseMessage.NONE_SENIOR.getMessage()));
+                .andExpect(jsonPath("$.code").value(SENIOR_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(NOT_FOUND_SENIOR.getMessage()));
     }
 
     @Test

--- a/src/test/java/com/postgraduate/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/postgraduate/domain/auth/presentation/AuthControllerTest.java
@@ -12,8 +12,6 @@ import com.postgraduate.domain.wish.domain.entity.constant.Status;
 import com.postgraduate.domain.wish.domain.repository.WishRepository;
 import com.postgraduate.global.config.redis.RedisRepository;
 import com.postgraduate.global.config.security.jwt.util.JwtUtils;
-import com.postgraduate.global.exception.constant.ErrorCode;
-import com.postgraduate.global.exception.constant.ErrorMessage;
 import com.postgraduate.global.slack.SlackMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -37,6 +35,7 @@ import static com.postgraduate.domain.user.domain.entity.constant.Role.SENIOR;
 import static com.postgraduate.domain.user.domain.entity.constant.Role.USER;
 import static com.postgraduate.domain.user.presentation.constant.UserResponseCode.USER_NOT_FOUND;
 import static com.postgraduate.domain.user.presentation.constant.UserResponseMessage.NOT_FOUND_USER;
+import static com.postgraduate.global.exception.constant.ErrorCode.VALID_BLANK;
 import static java.lang.Boolean.FALSE;
 import static java.time.LocalDateTime.now;
 import static org.mockito.ArgumentMatchers.any;
@@ -123,7 +122,7 @@ class AuthControllerTest extends IntegrationTest {
         authLoginByAnonymousUser();
 
         String request = objectMapper.writeValueAsString(
-                new SignUpRequest(anonymousUserSocialId, "01012345678", "nickname",
+                new SignUpRequest(anonymousUserSocialId, "01012345678", "새로운닉네임",
                         true, "major", "field", true)
         );
 
@@ -138,6 +137,24 @@ class AuthControllerTest extends IntegrationTest {
                 .andExpect(jsonPath("$.data.role").value(USER.name()));
     }
 
+    @Test
+    @DisplayName("닉네임은 6글자 이하만 허용한다")
+    void signUpUserInvalidNickName() throws Exception {
+        authLoginByAnonymousUser();
+
+        String request = objectMapper.writeValueAsString(
+                new SignUpRequest(anonymousUserSocialId, "01012345678", "nickname",
+                        true, "major", "field", true)
+        );
+
+        mvc.perform(post("/auth/user/signup")
+                        .content(request)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(VALID_BLANK.getCode()));
+    }
+
     @ParameterizedTest
     @NullAndEmptySource
     @DisplayName("희망 대학원/학과와 연구분야를 입력하지 않아도 대학생 회원가입이 가능하다.")
@@ -145,7 +162,7 @@ class AuthControllerTest extends IntegrationTest {
         authLoginByAnonymousUser();
 
         String request = objectMapper.writeValueAsString(
-                new SignUpRequest(anonymousUserSocialId, "01012345678", "nickname",
+                new SignUpRequest(anonymousUserSocialId, "01012345678", "새로운닉네임",
                         true, empty, empty, false)
         );
 
@@ -236,7 +253,7 @@ class AuthControllerTest extends IntegrationTest {
         authLoginByAnonymousUser();
 
         String request = objectMapper.writeValueAsString(
-                new SeniorSignUpRequest(anonymousUserSocialId, "01012345678", "nickname",
+                new SeniorSignUpRequest(anonymousUserSocialId, "01012345678", "새로운닉네임",
                         true, "전공", "서울대학교", "교수", "연구실",
                         "AI", "키워드", "certification")
         );
@@ -259,7 +276,7 @@ class AuthControllerTest extends IntegrationTest {
         authLoginByAnonymousUser();
 
         String request = objectMapper.writeValueAsString(
-                new SeniorSignUpRequest(anonymousUserSocialId, "01012345678", "nickname",
+                new SeniorSignUpRequest(anonymousUserSocialId, "01012345678", "새로운닉네임",
                         true, empty, empty, empty, empty, empty, empty, empty)
         );
 
@@ -268,8 +285,7 @@ class AuthControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()))
-                .andExpect(jsonPath("$.message").value(ErrorMessage.VALID_BLANK.getMessage()));
+                .andExpect(jsonPath("$.code").value(VALID_BLANK.getCode()));
     }
 
     @Test
@@ -310,8 +326,7 @@ class AuthControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()))
-                .andExpect(jsonPath("$.message").value(ErrorMessage.VALID_BLANK.getMessage()));
+                .andExpect(jsonPath("$.code").value(VALID_BLANK.getCode()));
     }
 
     @Test

--- a/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseCaseTest.java
@@ -216,7 +216,7 @@ class MentoringManageUseCaseTest {
 
         mentoringManageUseCase.updateRefuse(user, mentoringId, request);
 
-        verify(refuseSaveService).saveRefuse(any(Refuse.class));
+        verify(refuseSaveService).save(any(Refuse.class));
         verify(mentoringUpdateService).updateStatus(mentoring, REFUSE);
     }
 

--- a/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCaseTest.java
@@ -143,7 +143,7 @@ class MentoringSeniorInfoUseCaseTest {
 
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
-        given(mentoringGetService.mentoringBySenior(senior, WAITING))
+        given(mentoringGetService.bySenior(senior, WAITING))
                 .willReturn(mentorings);
 
         SeniorMentoringResponse seniorWaiting = mentoringSeniorInfoUseCase.getSeniorWaiting(user);
@@ -165,7 +165,7 @@ class MentoringSeniorInfoUseCaseTest {
 
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
-        given(mentoringGetService.mentoringBySenior(senior, EXPECTED))
+        given(mentoringGetService.bySenior(senior, EXPECTED))
                 .willReturn(mentorings);
 
         SeniorMentoringResponse seniorExpected = mentoringSeniorInfoUseCase.getSeniorExpected(user);
@@ -195,7 +195,7 @@ class MentoringSeniorInfoUseCaseTest {
 
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
-        given(mentoringGetService.mentoringBySenior(senior))
+        given(mentoringGetService.bySenior(senior))
                 .willReturn(dones);
 
         SeniorMentoringResponse seniorDone = mentoringSeniorInfoUseCase.getSeniorDone(user);

--- a/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCaseTest.java
@@ -122,21 +122,21 @@ class MentoringUserInfoUseCaseTest {
     void getWaiting() {
         Mentoring mentoring1 = new Mentoring(1L, user, senior
                 , "a", "b", "c"
-                , 40,  WAITING
+                , 40, WAITING
                 , LocalDateTime.now(), LocalDateTime.now());
 
         Mentoring mentoring2 = new Mentoring(2L, user, senior
                 , "a", "b", "c"
-                , 40,  WAITING
+                , 40, WAITING
                 , LocalDateTime.now(), LocalDateTime.now());
 
         Mentoring mentoring3 = new Mentoring(3L, user, senior
                 , "a", "b", "c"
-                , 40,  WAITING
+                , 40, WAITING
                 , LocalDateTime.now(), LocalDateTime.now());
         List<Mentoring> mentorings = List.of(mentoring1, mentoring2, mentoring3);
 
-        given(mentoringGetService.mentoringByUser(user, WAITING))
+        given(mentoringGetService.byUser(user, WAITING))
                 .willReturn(mentorings);
 
         AppliedMentoringResponse waiting = mentoringUserInfoUseCase.getWaiting(user);
@@ -150,21 +150,21 @@ class MentoringUserInfoUseCaseTest {
     void getExpected() {
         Mentoring mentoring1 = new Mentoring(1L, user, senior
                 , "a", "b", "c"
-                , 40,  EXPECTED
+                , 40, EXPECTED
                 , LocalDateTime.now(), LocalDateTime.now());
 
         Mentoring mentoring2 = new Mentoring(2L, user, senior
                 , "a", "b", "c"
-                , 40,  EXPECTED
+                , 40, EXPECTED
                 , LocalDateTime.now(), LocalDateTime.now());
 
         Mentoring mentoring3 = new Mentoring(3L, user, senior
                 , "a", "b", "c"
-                , 40,  EXPECTED
+                , 40, EXPECTED
                 , LocalDateTime.now(), LocalDateTime.now());
         List<Mentoring> mentorings = List.of(mentoring1, mentoring2, mentoring3);
 
-        given(mentoringGetService.mentoringByUser(user, EXPECTED))
+        given(mentoringGetService.byUser(user, EXPECTED))
                 .willReturn(mentorings);
 
         AppliedMentoringResponse expected = mentoringUserInfoUseCase.getExpected(user);
@@ -178,21 +178,21 @@ class MentoringUserInfoUseCaseTest {
     void getDone() {
         Mentoring mentoring1 = new Mentoring(1L, user, senior
                 , "a", "b", "c"
-                , 40,  DONE
+                , 40, DONE
                 , LocalDateTime.now(), LocalDateTime.now());
 
         Mentoring mentoring2 = new Mentoring(2L, user, senior
                 , "a", "b", "c"
-                , 40,  DONE
+                , 40, DONE
                 , LocalDateTime.now(), LocalDateTime.now());
 
         Mentoring mentoring3 = new Mentoring(3L, user, senior
                 , "a", "b", "c"
-                , 40,  DONE
+                , 40, DONE
                 , LocalDateTime.now(), LocalDateTime.now());
         List<Mentoring> mentorings = List.of(mentoring1, mentoring2, mentoring3);
 
-        given(mentoringGetService.mentoringByUser(user, DONE))
+        given(mentoringGetService.byUser(user, DONE))
                 .willReturn(mentorings);
 
         AppliedMentoringResponse done = mentoringUserInfoUseCase.getDone(user);

--- a/src/test/java/com/postgraduate/domain/mentoring/presentation/MentoringControllerTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/presentation/MentoringControllerTest.java
@@ -23,7 +23,6 @@ import com.postgraduate.domain.user.domain.entity.constant.Role;
 import com.postgraduate.domain.user.domain.repository.UserRepository;
 import com.postgraduate.global.config.security.jwt.util.JwtUtils;
 import com.postgraduate.global.exception.constant.ErrorCode;
-import com.postgraduate.global.exception.constant.ErrorMessage;
 import com.postgraduate.global.slack.SlackMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -215,8 +214,7 @@ class MentoringControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()))
-                .andExpect(jsonPath("$.message").value(ErrorMessage.VALID_BLANK.getMessage()));
+                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()));
     }
 
     @Test
@@ -384,8 +382,7 @@ class MentoringControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(MENTORING_NOT_WAITING.getCode()))
-                .andExpect(jsonPath("$.message").value(NOT_WAITING_MENTORING.getMessage()));
+                .andExpect(jsonPath("$.code").value(MENTORING_NOT_WAITING.getCode()));
     }
 
     @ParameterizedTest
@@ -402,8 +399,7 @@ class MentoringControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()))
-                .andExpect(jsonPath("$.message").value(ErrorMessage.VALID_BLANK.getMessage()));
+                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()));
     }
 
     @Test
@@ -437,8 +433,7 @@ class MentoringControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(MENTORING_NOT_WAITING.getCode()))
-                .andExpect(jsonPath("$.message").value(NOT_WAITING_MENTORING.getMessage()));
+                .andExpect(jsonPath("$.code").value(MENTORING_NOT_WAITING.getCode()));
     }
 
     @ParameterizedTest
@@ -455,7 +450,6 @@ class MentoringControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()))
-                .andExpect(jsonPath("$.message").value(ErrorMessage.VALID_BLANK.getMessage()));
+                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()));
     }
 }

--- a/src/test/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCaseTest.java
@@ -31,8 +31,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -124,12 +122,12 @@ class SeniorManageUseCaseTest {
     @DisplayName("Account없는 경우 계정 수정 테스트")
     void updateSeniorMyPageUserAccountWithNonAccount() {
         SeniorMyPageUserAccountRequest request =
-                new SeniorMyPageUserAccountRequest("a", "b", "a" , "b", "a", "b");
+                new SeniorMyPageUserAccountRequest("a", "b", "a", "b", "a", "b");
         Salary salary = mock(Salary.class);
 
         given(salaryGetService.bySenior(senior))
                 .willReturn(salary);
-        given(userGetService.getUser(user.getUserId()))
+        given(userGetService.byUserId(user.getUserId()))
                 .willReturn(user);
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
@@ -140,19 +138,19 @@ class SeniorManageUseCaseTest {
         verify(userUpdateService)
                 .updateSeniorUserAccount(user, request);
         verify(accountSaveService)
-                .saveAccount(any(Account.class));
+                .save(any(Account.class));
     }
 
     @Test
     @DisplayName("Account있는 경우 계정 수정 테스트")
     void updateSeniorMyPageUserAccountWithAccount() {
         SeniorMyPageUserAccountRequest request =
-                new SeniorMyPageUserAccountRequest("a", "b", "a" , "b", "a", "b");
+                new SeniorMyPageUserAccountRequest("a", "b", "a", "b", "a", "b");
         Salary salary = mock(Salary.class);
 
         given(salaryGetService.bySenior(senior))
                 .willReturn(salary);
-        given(userGetService.getUser(user.getUserId()))
+        given(userGetService.byUserId(user.getUserId()))
                 .willReturn(user);
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
@@ -186,7 +184,7 @@ class SeniorManageUseCaseTest {
     @DisplayName("번호 예외 테스트")
     void userAccountInvalidPhoneNumber() {
         SeniorMyPageUserAccountRequest request =
-                new SeniorMyPageUserAccountRequest("a", "1234", "a" , "b", "a", "b");
+                new SeniorMyPageUserAccountRequest("a", "1234", "a", "b", "a", "b");
 
         doThrow(PhoneNumberException.class)
                 .when(userUtils)

--- a/src/test/java/com/postgraduate/domain/senior/presentation/SeniorControllerTest.java
+++ b/src/test/java/com/postgraduate/domain/senior/presentation/SeniorControllerTest.java
@@ -22,7 +22,6 @@ import com.postgraduate.domain.user.domain.entity.constant.Role;
 import com.postgraduate.domain.user.domain.repository.UserRepository;
 import com.postgraduate.global.config.security.jwt.util.JwtUtils;
 import com.postgraduate.global.exception.constant.ErrorCode;
-import com.postgraduate.global.exception.constant.ErrorMessage;
 import com.postgraduate.global.slack.SlackMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -138,8 +137,7 @@ class SeniorControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()))
-                .andExpect(jsonPath("$.message").value(ErrorMessage.VALID_BLANK.getMessage()));
+                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()));
     }
 
     @Test
@@ -179,8 +177,7 @@ class SeniorControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()))
-                .andExpect(jsonPath("$.message").value(ErrorMessage.VALID_BLANK.getMessage()));
+                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()));
     }
 
     @Test
@@ -242,8 +239,7 @@ class SeniorControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()))
-                .andExpect(jsonPath("$.message").value(ErrorMessage.VALID_BLANK.getMessage()));
+                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()));
     }
 
     @Test
@@ -335,8 +331,7 @@ class SeniorControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()))
-                .andExpect(jsonPath("$.message").value(ErrorMessage.VALID_BLANK.getMessage()));
+                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()));
     }
 
     @ParameterizedTest
@@ -359,8 +354,7 @@ class SeniorControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()))
-                .andExpect(jsonPath("$.message").value(ErrorMessage.VALID_BLANK.getMessage()));
+                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()));
     }
 
     @Test
@@ -456,8 +450,7 @@ class SeniorControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()))
-                .andExpect(jsonPath("$.message").value(ErrorMessage.VALID_BLANK.getMessage()));
+                .andExpect(jsonPath("$.code").value(ErrorCode.VALID_BLANK.getCode()));
     }
 
     @ParameterizedTest

--- a/src/test/java/com/postgraduate/domain/senior/presentation/SeniorControllerTest.java
+++ b/src/test/java/com/postgraduate/domain/senior/presentation/SeniorControllerTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -126,6 +127,7 @@ class SeniorControllerTest extends IntegrationTest {
 
     @ParameterizedTest
     @NullAndEmptySource
+    @WithMockUser(authorities = {"SENIOR"})
     @DisplayName("잘못된 이미지로 인증한다")
     void updateInvalidCertification(String certification) throws Exception {
         String request = objectMapper.writeValueAsString(
@@ -224,6 +226,7 @@ class SeniorControllerTest extends IntegrationTest {
 
     @ParameterizedTest
     @NullAndEmptySource
+    @WithMockUser(authorities = {"SENIOR"})
     @DisplayName("빈 정산 계좌를 입력으면 예외가 발생한다")
     void updateInvalidAccount(String empty) throws Exception {
         Salary salary = new Salary(0L, false, senior, null, 10000, getSalaryDate(), now(), null, null, null);
@@ -313,6 +316,7 @@ class SeniorControllerTest extends IntegrationTest {
 
     @ParameterizedTest
     @NullAndEmptySource
+    @WithMockUser(authorities = {"SENIOR"})
     @DisplayName("가능 시간대가 비어있으면 예외가 발생한다")
     void updateInvalidAvailableSeniorProfile(String empty) throws Exception {
         List<AvailableCreateRequest> availableCreateRequests = List.of(
@@ -336,6 +340,7 @@ class SeniorControllerTest extends IntegrationTest {
 
     @ParameterizedTest
     @NullAndEmptySource
+    @WithMockUser(authorities = {"SENIOR"})
     @DisplayName("프로필이 비어있으면 예외가 발생한다")
     void updateInvalidSeniorProfile(String empty) throws Exception {
         List<AvailableCreateRequest> availableCreateRequests = List.of(
@@ -435,6 +440,7 @@ class SeniorControllerTest extends IntegrationTest {
 
     @ParameterizedTest
     @NullAndEmptySource
+    @WithMockUser(authorities = {"SENIOR"})
     @DisplayName("대학원생 마이페이지 계정을 수정 요청에 닉네임, 전화번호, 프로필사진이 없다면 예외가 발생한다")
     void updateEmptySeniorUserAccount(String empty) throws Exception {
         Salary salary = new Salary(0L, false, senior, null, 10000, getSalaryDate(), now(), null, null, null);
@@ -504,6 +510,7 @@ class SeniorControllerTest extends IntegrationTest {
     }
 
     @Test
+    @WithMockUser(authorities = {"USER", "SENIOR", "ADMIN"})
     @DisplayName("대학원생을 상세 조회한다 - 타인 조회")
     void getSeniorDetailsOthers() throws Exception {
         updateProfile();
@@ -531,6 +538,7 @@ class SeniorControllerTest extends IntegrationTest {
 
     @ParameterizedTest
     @EnumSource(value = Status.class, names = {"NOT_APPROVE", "WAITING"})
+    @WithMockUser(authorities = {"USER", "SENIOR", "ADMIN"})
     @DisplayName("승인되지 않은 대학원생은 조회되지 않는다.")
     void getNotApprovedSeniorDetails(Status status) throws Exception {
         senior.updateStatus(status);
@@ -543,6 +551,7 @@ class SeniorControllerTest extends IntegrationTest {
     }
 
     @Test
+    @WithMockUser(authorities = {"USER"})
     @DisplayName("결제 시 대학원생의 기본 정보를 확인한다")
     void testGetSeniorProfile() throws Exception {
         updateProfile();
@@ -560,6 +569,7 @@ class SeniorControllerTest extends IntegrationTest {
     }
 
     @Test
+    @WithMockUser(authorities = {"USER"})
     @DisplayName("신청서 작성 시 대학원생의 가능 시간 정보를 조회한다")
     void getSeniorTimes() throws Exception {
         updateProfile();

--- a/src/test/java/com/postgraduate/domain/senior/presentation/SeniorControllerTest.java
+++ b/src/test/java/com/postgraduate/domain/senior/presentation/SeniorControllerTest.java
@@ -289,8 +289,8 @@ class SeniorControllerTest extends IntegrationTest {
         mvc.perform(get("/senior/me/profile")
                         .header(AUTHORIZATION, BEARER + token))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(SeniorResponseCode.NONE_PROFILE.getCode()))
-                .andExpect(jsonPath("$.message").value(SeniorResponseMessage.NONE_PROFILE.getMessage()));
+                .andExpect(jsonPath("$.code").value(PROFILE_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(NOT_FOUND_PROFILE.getMessage()));
     }
 
     @Test
@@ -436,7 +436,7 @@ class SeniorControllerTest extends IntegrationTest {
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(SENIOR_UPDATE.getCode()))
-                .andExpect(jsonPath("$.message").value(UPDATE_MYPAGE_ACCOOUNT.getMessage()));
+                .andExpect(jsonPath("$.message").value(UPDATE_MYPAGE_ACCOUNT.getMessage()));
     }
 
     @ParameterizedTest
@@ -480,8 +480,8 @@ class SeniorControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(SeniorResponseCode.NONE_ACCOUNT.getCode()))
-                .andExpect(jsonPath("$.message").value(SeniorResponseMessage.NONE_ACCOUNT.getMessage()));
+                .andExpect(jsonPath("$.code").value(ACCOUNT_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(NOT_FOUND_ACCOUNT.getMessage()));
     }
 
     @Test
@@ -545,8 +545,8 @@ class SeniorControllerTest extends IntegrationTest {
 
         mvc.perform(get("/senior/{seniorId}", senior.getSeniorId()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(SeniorResponseCode.NONE_SENIOR.getCode()))
-                .andExpect(jsonPath("$.message").value(SeniorResponseMessage.NONE_SENIOR.getMessage()));
+                .andExpect(jsonPath("$.code").value(SENIOR_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(NOT_FOUND_SENIOR.getMessage()));
     }
 
     @Test

--- a/src/test/java/com/postgraduate/domain/user/domain/service/UserGetServiceTest.java
+++ b/src/test/java/com/postgraduate/domain/user/domain/service/UserGetServiceTest.java
@@ -28,7 +28,7 @@ class UserGetServiceTest {
         given(userRepository.findById(userId))
                 .willReturn(Optional.ofNullable(null));
 
-        assertThatThrownBy(() -> userGetService.getUser(userId))
+        assertThatThrownBy(() -> userGetService.byUserId(userId))
                 .isInstanceOf(UserNotFoundException.class);
     }
 }


### PR DESCRIPTION
## 🦝 PR 요약
+ 전체 코드 통일성 점검했습니다.

## ✨ PR 상세 내용
+ ResponseCode 및 Message 통일
+ Method 명 통일
+ Request 유효성 검사


## 🚨 주의 사항
+ Request에 null이 `@Valid`에 잡히지 않아서 `@NotNull`을 추가했습니다.
+ `@Valid` response message 수정
+ `@NotBlank`
```
    "code": "EX1100",
    "message": "공백일 수 없습니다"
```
+ `@NotNull`
```
    "code": "EX1100",
    "message": "널이어서는 안됩니다"
```
+ `@Size`
```
    "code": "EX1100",
    "message": "6글자까지 입력 가능합니다."
```

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
