### PR TITLE
RAC-276 fix : 환불 실패 커스텀 예외 수정

### DIFF
--- a/src/main/java/com/postgraduate/domain/payment/application/usecase/PaymentManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/payment/application/usecase/PaymentManageUseCase.java
@@ -107,8 +107,9 @@ public class PaymentManageUseCase {
     }
 
     private void refundProcess(CertificationResponse response, Payment payment) {
-        if (!response.result().equals(SUCCESS.getName()))
-            throw new CertificationFailException();
+        if (!response.result().equals(SUCCESS.getName())) {
+            throw new CertificationFailException(response.result_msg());
+        }
         RefundResponse refundResponse = Optional.ofNullable(webClient.post()
                 .uri(refundUri + response.PCD_PAY_URL())
                 .headers(h -> {

--- a/src/main/java/com/postgraduate/domain/payment/exception/CertificationFailException.java
+++ b/src/main/java/com/postgraduate/domain/payment/exception/CertificationFailException.java
@@ -2,13 +2,12 @@ package com.postgraduate.domain.payment.exception;
 
 import com.postgraduate.global.exception.ApplicationException;
 
-import static com.postgraduate.domain.payment.presentation.constant.PaymentResponseCode.CERTIFICATION_DENIED;
 import static com.postgraduate.domain.payment.presentation.constant.PaymentResponseMessage.DENIED_CERTIFICATION;
 
 
 public class CertificationFailException extends ApplicationException {
 
-    public CertificationFailException() {
-        super(DENIED_CERTIFICATION.getMessage(), CERTIFICATION_DENIED.getCode());
+    public CertificationFailException(String code) {
+        super(DENIED_CERTIFICATION.getMessage(), code);
     }
 }

--- a/src/main/java/com/postgraduate/domain/payment/presentation/constant/PaymentResponseCode.java
+++ b/src/main/java/com/postgraduate/domain/payment/presentation/constant/PaymentResponseCode.java
@@ -12,8 +12,7 @@ public enum PaymentResponseCode {
     PAYMENT_DELETE("PM203"),
 
     PAYMENT_NOT_FOUND("EX600"),
-    PAYMENT_FAIL("EX601"),
-    CERTIFICATION_DENIED("EX602");
+    PAYMENT_FAIL("EX601");
 
     private final String code;
 }


### PR DESCRIPTION
## 🦝 PR 요약
환불 실패 커스텀 예외 수정

## ✨ PR 상세 내용
환불 실패 커스텀 예외 수정
- 예외 코드 (페이플 제공 예외 코드로 발생)

## 🚨 주의 사항
주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
