### PR TITLE
RAC-304 fix : Payment, Salary, Mentoring 관계 수정 및 결제 실패시 로직 수정

### DIFF
--- a/src/main/java/com/postgraduate/domain/mentoring/application/mapper/MentoringMapper.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/mapper/MentoringMapper.java
@@ -109,8 +109,8 @@ public class MentoringMapper {
                 dDay);
     }
 
-    public static DoneSeniorMentoringInfo mapToSeniorDoneInfo(Mentoring mentoring, Payment payment) {
-        Salary salary = payment.getSalary();
+    public static DoneSeniorMentoringInfo mapToSeniorDoneInfo(Mentoring mentoring) {
+        Salary salary = mentoring.getSalary();
         User user = mentoring.getUser();
         return new DoneSeniorMentoringInfo(mentoring.getMentoringId(),
                 user.getProfile(), user.getNickName(),

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseCase.java
@@ -146,10 +146,9 @@ public class MentoringManageUseCase {
         //TODO : 알림 보내거나 나머지 작업
     }
 
-    @Scheduled(fixedRate = 6000, zone = "Asia/Seoul")
+    @Scheduled(cron = "0 59 23 * * *", zone = "Asia/Seoul")
     public void updateAutoDone() {
         List<Mentoring> expectedMentorings = mentoringGetService.byStatus(EXPECTED);
-        log.info("크기 : {}", expectedMentorings.size());
         expectedMentorings.stream()
                 .filter(mentoring -> {
                     try {

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringRenewalUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringRenewalUseCase.java
@@ -54,10 +54,10 @@ public class MentoringRenewalUseCase {
     public void updateDoneWithAuto(Mentoring mentoring) {
         try {
             Mentoring doneMentoring = mentoringGetService.byMentoringIdWithLazy(mentoring.getMentoringId());
-            mentoringUpdateService.updateStatus(doneMentoring, DONE);
             Senior senior = mentoring.getSenior();
             Salary salary = salaryGetService.bySenior(senior);
             salaryUpdateService.updateTotalAmount(salary);
+            mentoringUpdateService.updateDone(doneMentoring, salary);
             log.info("mentoringId : {} 자동 완료", mentoring.getMentoringId());
         } catch (Exception ex) {
             slackErrorMessage.sendSlackError(mentoring, ex);

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCase.java
@@ -5,6 +5,7 @@ import com.postgraduate.domain.mentoring.application.dto.ExpectedSeniorMentoring
 import com.postgraduate.domain.mentoring.application.dto.WaitingSeniorMentoringInfo;
 import com.postgraduate.domain.mentoring.application.dto.res.SeniorMentoringDetailResponse;
 import com.postgraduate.domain.mentoring.application.dto.res.SeniorMentoringResponse;
+import com.postgraduate.domain.mentoring.application.mapper.MentoringMapper;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.mentoring.domain.entity.constant.Status;
 import com.postgraduate.domain.mentoring.domain.service.MentoringGetService;
@@ -74,7 +75,7 @@ public class MentoringSeniorInfoUseCase {
     public SeniorMentoringResponse getSeniorDone(User user) {
         List<Mentoring> mentorings = getDoneMentorings(user);
         List<DoneSeniorMentoringInfo> doneSeniorMentoringInfos = mentorings.stream()
-                .map(mentoirng -> mapToSeniorDoneInfo(mentoirng, mentoirng.getPayment()))
+                .map(MentoringMapper::mapToSeniorDoneInfo)
                 .toList();
         return new SeniorMentoringResponse(doneSeniorMentoringInfos);
     }

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/entity/Mentoring.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/entity/Mentoring.java
@@ -2,6 +2,7 @@ package com.postgraduate.domain.mentoring.domain.entity;
 
 import com.postgraduate.domain.mentoring.domain.entity.constant.Status;
 import com.postgraduate.domain.payment.domain.entity.Payment;
+import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
 import jakarta.persistence.*;
@@ -15,6 +16,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+import static com.postgraduate.domain.mentoring.domain.entity.constant.Status.DONE;
 import static java.time.LocalDateTime.now;
 import static java.time.LocalDateTime.parse;
 import static java.time.format.DateTimeFormatter.ofPattern;
@@ -37,6 +39,9 @@ public class Mentoring {
 
     @OneToOne(fetch = FetchType.LAZY)
     private Payment payment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Salary salary;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String topic;
@@ -63,6 +68,11 @@ public class Mentoring {
 
     public void updateStatus(Status status) {
         this.status = status;
+    }
+
+    public void updateDone(Salary salary) {
+        this.status = DONE;
+        this.salary = salary;
     }
 
     public void updateDate(String date) {

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringDslRepositoryImpl.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringDslRepositoryImpl.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 
 import static com.postgraduate.domain.mentoring.domain.entity.QMentoring.mentoring;
 import static com.postgraduate.domain.payment.domain.entity.QPayment.payment;
-import static com.postgraduate.domain.payment.domain.entity.constant.Status.DONE;
 import static com.postgraduate.domain.salary.domain.entity.QSalary.salary;
 import static com.postgraduate.domain.senior.domain.entity.QSenior.senior;
 import static com.postgraduate.domain.user.domain.entity.QUser.user;
@@ -111,16 +110,13 @@ public class MentoringDslRepositoryImpl implements MentoringDslRepository {
                 .where(
                         mentoring.senior.eq(senior),
                         mentoring.status.eq(Status.DONE),
-                        mentoring.payment.status.eq(DONE),
-                        mentoring.payment.salary.status.eq(status)
+                        mentoring.salary.status.eq(status)
                 )
-                .join(mentoring.payment, payment)
-                .fetchJoin()
-                .join(mentoring.payment.salary, salary)
+                .join(mentoring.salary, salary)
                 .fetchJoin()
                 .join(mentoring.user, user)
                 .fetchJoin()
-                .orderBy(mentoring.payment.salary.salaryDate.desc(), mentoring.updatedAt.desc())
+                .orderBy(mentoring.salary.salaryDate.desc(), mentoring.updatedAt.desc())
                 .fetch();
     }
 
@@ -179,7 +175,7 @@ public class MentoringDslRepositoryImpl implements MentoringDslRepository {
                 .distinct()
                 .join(mentoring.senior, senior)
                 .fetchJoin()
-                .join(mentoring.payment.salary, salary)
+                .join(mentoring.salary, salary)
                 .fetchJoin()
                 .where(mentoring.status.eq(status))
                 .fetch();

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringUpdateService.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringUpdateService.java
@@ -2,6 +2,7 @@ package com.postgraduate.domain.mentoring.domain.service;
 
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.mentoring.domain.entity.constant.Status;
+import com.postgraduate.domain.salary.domain.entity.Salary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,6 +12,10 @@ public class MentoringUpdateService {
 
     public void updateStatus(Mentoring mentoring, Status status) {
         mentoring.updateStatus(status);
+    }
+
+    public void updateDone(Mentoring mentoring, Salary salary) {
+        mentoring.updateDone(salary);
     }
 
     public void updateDate(Mentoring mentoring, String date) {

--- a/src/main/java/com/postgraduate/domain/payment/application/mapper/PaymentMapper.java
+++ b/src/main/java/com/postgraduate/domain/payment/application/mapper/PaymentMapper.java
@@ -2,7 +2,7 @@ package com.postgraduate.domain.payment.application.mapper;
 
 import com.postgraduate.domain.payment.application.dto.req.PaymentResultRequest;
 import com.postgraduate.domain.payment.domain.entity.Payment;
-import com.postgraduate.domain.salary.domain.entity.Salary;
+import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
 
 import java.time.LocalDateTime;
@@ -13,11 +13,11 @@ public class PaymentMapper {
         throw new IllegalArgumentException();
     }
 
-    public static Payment resultToPayment(Salary salary, User user, PaymentResultRequest request) {
+    public static Payment resultToPayment(Senior senior, User user, PaymentResultRequest request) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
         return Payment.builder()
-                .salary(salary)
                 .user(user)
+                .senior(senior)
                 .pay(Integer.parseInt(request.PCD_PAY_TOTAL()))
                 .orderId(request.PCD_PAY_OID())
                 .cardAuthNumber(request.PCD_PAY_CARDAUTHNO())
@@ -29,8 +29,6 @@ public class PaymentMapper {
     public static Payment resultToPayment(PaymentResultRequest request) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
         return Payment.builder()
-                .salary(null)
-                .user(null)
                 .pay(Integer.parseInt(request.PCD_PAY_TOTAL()))
                 .orderId(request.PCD_PAY_OID())
                 .cardAuthNumber(request.PCD_PAY_CARDAUTHNO())

--- a/src/main/java/com/postgraduate/domain/payment/domain/entity/Payment.java
+++ b/src/main/java/com/postgraduate/domain/payment/domain/entity/Payment.java
@@ -1,7 +1,7 @@
 package com.postgraduate.domain.payment.domain.entity;
 
 import com.postgraduate.domain.payment.domain.entity.constant.Status;
-import com.postgraduate.domain.salary.domain.entity.Salary;
+import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -24,10 +24,10 @@ public class Payment {
     private Long paymentId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Salary salary;
+    private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private User user;
+    private Senior senior;
 
     @Column(nullable = false)
     private int pay;

--- a/src/main/java/com/postgraduate/domain/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/postgraduate/domain/payment/domain/repository/PaymentRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long>, PaymentDslRepository {
     Optional<Payment> findByUserAndOrderIdAndStatus(User user, String orderId, Status status);
-    Optional<Payment> findBySalary_SeniorAndOrderIdAndStatus(Senior senior, String orderId, Status status);
+    Optional<Payment> findBySeniorAndOrderIdAndStatus(Senior senior, String orderId, Status status);
 }

--- a/src/main/java/com/postgraduate/domain/payment/domain/service/PaymentGetService.java
+++ b/src/main/java/com/postgraduate/domain/payment/domain/service/PaymentGetService.java
@@ -20,6 +20,6 @@ public class PaymentGetService {
     }
 
     public Payment bySeniorAndOrderId(Senior senior, String orderId) {
-        return paymentRepository.findBySalary_SeniorAndOrderIdAndStatus(senior, orderId, DONE).orElseThrow(PaymentNotFoundException::new);
+        return paymentRepository.findBySeniorAndOrderIdAndStatus(senior, orderId, DONE).orElseThrow(PaymentNotFoundException::new);
     }
 }

--- a/src/main/java/com/postgraduate/domain/payment/presentation/PaymentController.java
+++ b/src/main/java/com/postgraduate/domain/payment/presentation/PaymentController.java
@@ -24,29 +24,17 @@ public class PaymentController {
     private String redirectUri;
     @Value("${payple.redirect-uri-dev}")
     private String redirectUriDev;
-    @Value("${payple.cancel-redirect-uri}")
-    private String cancelRedirectUri;
-    @Value("${payple.cancel-redirect-uri-dev}")
-    private String cancelRedirectUriDev;
 
     @PostMapping("/payple/result")
     public void resultGet(HttpServletResponse response, @ModelAttribute PaymentResultRequest request) throws IOException {
-        if (paymentManageUseCase.savePay(request)) {
-            response.sendRedirect(redirectUri + request.PCD_PAY_OID());
-            return;
-        }
-        Long seniorId = seniorInfoUseCase.getSeniorId(request.PCD_PAY_GOODS());
-        response.sendRedirect(cancelRedirectUri + seniorId);
+        paymentManageUseCase.savePay(request);
+        response.sendRedirect(redirectUri + request.PCD_PAY_OID());
     }
 
     @PostMapping("/payple/dev/result")
     public void resultGetWithDev(HttpServletResponse response, @ModelAttribute PaymentResultRequest request) throws IOException {
-        if (paymentManageUseCase.savePay(request)) {
-            response.sendRedirect(redirectUriDev + request.PCD_PAY_OID());
-            return;
-        }
-        Long seniorId = seniorInfoUseCase.getSeniorId(request.PCD_PAY_GOODS());
-        response.sendRedirect(cancelRedirectUriDev + seniorId);
+        paymentManageUseCase.savePay(request);
+        response.sendRedirect(redirectUriDev + request.PCD_PAY_OID());
     }
 
     @PostMapping("/webhook")

--- a/src/main/java/com/postgraduate/domain/salary/application/mapper/SalaryMapper.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/mapper/SalaryMapper.java
@@ -35,7 +35,8 @@ public class SalaryMapper {
                 .build();
     }
 
-    public static SalaryDetails mapToSalaryDetail(Salary salary, Mentoring mentoring) {
+    public static SalaryDetails mapToSalaryDetail(Mentoring mentoring) {
+        Salary salary = mentoring.getSalary();
         User user = mentoring.getUser();
         return new SalaryDetails(
                 user.getProfile(),

--- a/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryInfoUseCase.java
@@ -40,7 +40,7 @@ public class SalaryInfoUseCase {
         Senior senior = seniorGetService.byUser(user);
         List<Mentoring> mentorings = mentoringGetService.bySeniorAndSalaryStatus(senior, status);
         List<SalaryDetails> salaryDetails = mentorings.stream()
-                .map(mentoring -> SalaryMapper.mapToSalaryDetail(mentoring.getPayment().getSalary(), mentoring))
+                .map(SalaryMapper::mapToSalaryDetail)
                 .toList();
         return new SalaryDetailsResponse(salaryDetails);
     }

--- a/src/main/java/com/postgraduate/domain/salary/domain/entity/Salary.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/entity/Salary.java
@@ -1,6 +1,5 @@
 package com.postgraduate.domain.salary.domain.entity;
 
-import com.postgraduate.domain.payment.domain.entity.Payment;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -10,7 +9,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Entity
 @Builder
@@ -28,9 +26,6 @@ public class Salary {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Senior senior;
-
-    @OneToMany(mappedBy = "salary", cascade = CascadeType.ALL)
-    private List<Payment> payments;
 
     @Builder.Default
     @Column(nullable = false)

--- a/src/main/java/com/postgraduate/domain/salary/util/SalaryUtil.java
+++ b/src/main/java/com/postgraduate/domain/salary/util/SalaryUtil.java
@@ -20,8 +20,8 @@ public class SalaryUtil {
         LocalDate now = LocalDate.now();
         DayOfWeek dayOfWeek = now.getDayOfWeek();
         return dayOfWeek.getValue() < SALARY_END_DATE
-                ? now.plusDays(7 + (dayOfWeek.getValue() - SALARY_DATE))
-                : now.plusDays(dayOfWeek.getValue() - SALARY_DATE);
+                ? now.plusDays(6 + (dayOfWeek.getValue() - SALARY_DATE))
+                : now.plusDays(SALARY_DATE);
     }
 
     public static SalaryStatus getStatus(Salary salary) {

--- a/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCaseTest.java
@@ -52,7 +52,7 @@ class MentoringSeniorInfoUseCaseTest {
         Senior senior = mock(Senior.class);
         Payment payment = mock(Payment.class);
 
-        Mentoring mentoring = new Mentoring(mentoringId, user, senior, payment
+        Mentoring mentoring = new Mentoring(mentoringId, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, EXPECTED
                 , LocalDateTime.now(), LocalDateTime.now());
@@ -74,7 +74,7 @@ class MentoringSeniorInfoUseCaseTest {
         Senior senior = mock(Senior.class);
         Payment payment = mock(Payment.class);
 
-        Mentoring mentoring = new Mentoring(mentoringId, user, senior, payment
+        Mentoring mentoring = new Mentoring(mentoringId, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, DONE
                 , LocalDateTime.now(), LocalDateTime.now());
@@ -96,7 +96,7 @@ class MentoringSeniorInfoUseCaseTest {
         Senior senior = mock(Senior.class);
         Payment payment = mock(Payment.class);
 
-        Mentoring mentoring = new Mentoring(mentoringId, user, senior, payment
+        Mentoring mentoring = new Mentoring(mentoringId, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, REFUSE
                 , LocalDateTime.now(), LocalDateTime.now());
@@ -118,7 +118,7 @@ class MentoringSeniorInfoUseCaseTest {
         Senior senior = mock(Senior.class);
         Payment payment = mock(Payment.class);
 
-        Mentoring mentoring = new Mentoring(mentoringId, user, senior, payment
+        Mentoring mentoring = new Mentoring(mentoringId, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, CANCEL
                 , LocalDateTime.now(), LocalDateTime.now());
@@ -139,9 +139,9 @@ class MentoringSeniorInfoUseCaseTest {
         Senior senior = mock(Senior.class);
         Payment payment = mock(Payment.class);
 
-        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
-        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
-        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
+        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment, null, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
+        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment, null, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
+        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment, null, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
         List<Mentoring> mentorings = List.of(mentoring1, mentoring2, mentoring3);
 
         given(seniorGetService.byUser(user))
@@ -162,9 +162,9 @@ class MentoringSeniorInfoUseCaseTest {
         Senior senior = mock(Senior.class);
         Payment payment = mock(Payment.class);
 
-        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment, "A", "b", "2024-01-20-17-00", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
-        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment, "A", "b", "2024-01-20-17-00", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
-        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment, "A", "b", "2024-01-20-17-00", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
+        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment, null, "A", "b", "2024-01-20-17-00", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
+        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment, null, "A", "b", "2024-01-20-17-00", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
+        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment, null, "A", "b", "2024-01-20-17-00", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
         List<Mentoring> mentorings = List.of(mentoring1, mentoring2, mentoring3);
 
         given(seniorGetService.byUser(user))
@@ -185,13 +185,13 @@ class MentoringSeniorInfoUseCaseTest {
         Senior senior = mock(Senior.class);
         Salary salary = mock(Salary.class);
 
-        Payment payment1 = new Payment(1l, salary, user, 10000, "1", "1", "a", LocalDateTime.now(), LocalDateTime.now(), Status.DONE);
-        Payment payment2 = new Payment(2l, salary, user, 10000, "1", "1", "a", LocalDateTime.now(), LocalDateTime.now(), Status.DONE);
-        Payment payment3 = new Payment(3l, salary, user, 10000, "1", "1", "a", LocalDateTime.now(), LocalDateTime.now(), Status.DONE);
+        Payment payment1 = new Payment(1l, user, senior, 10000, "1", "1", "a", LocalDateTime.now(), LocalDateTime.now(), Status.DONE);
+        Payment payment2 = new Payment(2l, user, senior, 10000, "1", "1", "a", LocalDateTime.now(), LocalDateTime.now(), Status.DONE);
+        Payment payment3 = new Payment(3l, user, senior, 10000, "1", "1", "a", LocalDateTime.now(), LocalDateTime.now(), Status.DONE);
 
-        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment1, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
-        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment2, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
-        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment3, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
+        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment1, salary, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
+        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment2, salary, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
+        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment3, salary, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
         List<Mentoring> mentorings = List.of(mentoring1, mentoring2, mentoring3);
 
         given(seniorGetService.byUser(user))

--- a/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCaseTest.java
@@ -64,7 +64,7 @@ class MentoringUserInfoUseCaseTest {
     void getMentoringDetail() {
         Payment payment = mock(Payment.class);
 
-        mentoring = new Mentoring(mentoringId, user, senior, payment
+        mentoring = new Mentoring(mentoringId, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, EXPECTED
                 , LocalDateTime.now(), LocalDateTime.now());
@@ -81,7 +81,7 @@ class MentoringUserInfoUseCaseTest {
     void getMentoringDetailFailWithDone() {
         Payment payment = mock(Payment.class);
 
-        mentoring = new Mentoring(mentoringId, user, senior, payment
+        mentoring = new Mentoring(mentoringId, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, DONE
                 , LocalDateTime.now(), LocalDateTime.now());
@@ -98,7 +98,7 @@ class MentoringUserInfoUseCaseTest {
     void getMentoringDetailFailWithRefuse() {
         Payment payment = mock(Payment.class);
 
-        mentoring = new Mentoring(mentoringId, user, senior, payment
+        mentoring = new Mentoring(mentoringId, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, REFUSE
                 , LocalDateTime.now(), LocalDateTime.now());
@@ -115,7 +115,7 @@ class MentoringUserInfoUseCaseTest {
     void getMentoringDetailFailWithCancel() {
         Payment payment = mock(Payment.class);
 
-        mentoring = new Mentoring(mentoringId, user, senior, payment
+        mentoring = new Mentoring(mentoringId, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, CANCEL
                 , LocalDateTime.now(), LocalDateTime.now());
@@ -132,17 +132,17 @@ class MentoringUserInfoUseCaseTest {
     void getWaiting() {
         Payment payment = mock(Payment.class);
 
-        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment
+        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, WAITING
                 , LocalDateTime.now(), LocalDateTime.now());
 
-        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment
+        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, WAITING
                 , LocalDateTime.now(), LocalDateTime.now());
 
-        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment
+        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, WAITING
                 , LocalDateTime.now(), LocalDateTime.now());
@@ -162,17 +162,17 @@ class MentoringUserInfoUseCaseTest {
     void getExpected() {
         Payment payment = mock(Payment.class);
 
-        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment
+        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, EXPECTED
                 , LocalDateTime.now(), LocalDateTime.now());
 
-        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment
+        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, EXPECTED
                 , LocalDateTime.now(), LocalDateTime.now());
 
-        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment
+        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, EXPECTED
                 , LocalDateTime.now(), LocalDateTime.now());
@@ -192,17 +192,17 @@ class MentoringUserInfoUseCaseTest {
     void getDone() {
         Payment payment = mock(Payment.class);
 
-        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment
+        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, DONE
                 , LocalDateTime.now(), LocalDateTime.now());
 
-        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment
+        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, DONE
                 , LocalDateTime.now(), LocalDateTime.now());
 
-        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment
+        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment, null
                 , "a", "b", "c"
                 , 40, DONE
                 , LocalDateTime.now(), LocalDateTime.now());

--- a/src/test/java/com/postgraduate/domain/mentoring/domain/service/MentoringUpdateServiceTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/domain/service/MentoringUpdateServiceTest.java
@@ -2,6 +2,7 @@ package com.postgraduate.domain.mentoring.domain.service;
 
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.payment.domain.entity.Payment;
+import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,21 +24,23 @@ class MentoringUpdateServiceTest {
     private MentoringUpdateService mentoringUpdateService;
 
     private Mentoring mentoring;
+    private Salary salary;
     private
     @BeforeEach
     void setting() {
         User user = mock(User.class);
         Senior senior = mock(Senior.class);
         Payment payment = mock(Payment.class);
+        salary = mock(Salary.class);
 
-        mentoring = new Mentoring(1L, user, senior, payment, "a", "a", "a", 1
+        mentoring = new Mentoring(1L, user, senior, payment, null, "a", "a", "a", 1
         , WAITING, LocalDateTime.now(), LocalDateTime.now());
     }
 
     @Test
     @DisplayName("DONE으로 변경")
     void updateStatusDone() {
-        mentoringUpdateService.updateStatus(mentoring, DONE);
+        mentoringUpdateService.updateDone(mentoring, salary);
         assertThat(mentoring.getStatus())
                 .isEqualTo(DONE);
     }

--- a/src/test/java/com/postgraduate/domain/salary/application/usecase/SalaryInfoUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/salary/application/usecase/SalaryInfoUseCaseTest.java
@@ -54,7 +54,7 @@ class SalaryInfoUseCaseTest {
     @DisplayName("정산 예정 금액 및 날짜 확인")
     void getSalary() {
         LocalDate salaryDate = getSalaryDate();
-        Salary salary = new Salary(1L, FALSE, senior, null, 10000, salaryDate, null, "bank", "1234", "holder");
+        Salary salary = new Salary(1L, FALSE, senior, 10000, salaryDate, null, "bank", "1234", "holder");
 
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
@@ -73,7 +73,7 @@ class SalaryInfoUseCaseTest {
     @DisplayName("정산 예정 금액 및 날짜 확인 - 0원")
     void getSalaryWithZero() {
         LocalDate salaryDate = getSalaryDate();
-        Salary salary = new Salary(1L, FALSE, senior, null, 0, salaryDate, null, "bank", "1234", "holder");
+        Salary salary = new Salary(1L, FALSE, senior, 0, salaryDate, null, "bank", "1234", "holder");
 
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
@@ -93,19 +93,19 @@ class SalaryInfoUseCaseTest {
     void getSalaryDetail() {
         Salary salary = mock(Salary.class);
 
-        Payment payment1 = new Payment(1L, salary, user, 1000, "a", "a", "a", LocalDateTime.now(), LocalDateTime.now(), Status.DONE);
-        Payment payment2 = new Payment(2L, salary, user, 1000, "a", "a", "a", LocalDateTime.now(), LocalDateTime.now(), Status.DONE);
-        Payment payment3 = new Payment(3L, salary, user, 1000, "a", "a", "a", LocalDateTime.now(), LocalDateTime.now(), Status.DONE);
+        Payment payment1 = new Payment(1L, user, senior, 1000, "a", "a", "a", LocalDateTime.now(), LocalDateTime.now(), Status.DONE);
+        Payment payment2 = new Payment(2L, user, senior, 1000, "a", "a", "a", LocalDateTime.now(), LocalDateTime.now(), Status.DONE);
+        Payment payment3 = new Payment(3L, user, senior, 1000, "a", "a", "a", LocalDateTime.now(), LocalDateTime.now(), Status.DONE);
 
-        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment1
+        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment1, salary
                 , "a", "b", "c"
                 , 40,  DONE
                 , LocalDateTime.now(), LocalDateTime.now());
-        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment2
+        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment2, salary
                 , "a", "b", "c"
                 , 40,  DONE
                 , LocalDateTime.now(), LocalDateTime.now());
-        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment3
+        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment3, salary
                 , "a", "b", "c"
                 , 40,  DONE
                 , LocalDateTime.now(), LocalDateTime.now());

--- a/src/test/java/com/postgraduate/domain/salary/domain/service/SalaryUpdateServiceTest.java
+++ b/src/test/java/com/postgraduate/domain/salary/domain/service/SalaryUpdateServiceTest.java
@@ -1,6 +1,5 @@
 package com.postgraduate.domain.salary.domain.service;
 
-import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +25,7 @@ class SalaryUpdateServiceTest {
     @DisplayName("정산 완료 테스트")
     void updateStatusTRUE() {
         Senior senior = mock(Senior.class);
-        Salary salary = new Salary(1L, FALSE, senior, null, 100, LocalDate.now(), LocalDateTime.now(), "a", "b", "c");
+        Salary salary = new Salary(1L, FALSE, senior, 100, LocalDate.now(), LocalDateTime.now(), "a", "b", "c");
 
         salaryUpdateService.updateStatus(salary, TRUE);
 
@@ -38,7 +37,7 @@ class SalaryUpdateServiceTest {
     @DisplayName("정산 금액 증가 테스트")
     void updateStatusFALSE() {
         Senior senior = mock(Senior.class);
-        Salary salary = new Salary(1L, TRUE, senior, null, 0, LocalDate.now(), LocalDateTime.now(), "a", "b", "c");
+        Salary salary = new Salary(1L, TRUE, senior, 0, LocalDate.now(), LocalDateTime.now(), "a", "b", "c");
 
         salaryUpdateService.updateTotalAmount(salary);
 

--- a/src/test/java/com/postgraduate/domain/salary/presentation/SalaryControllerTest.java
+++ b/src/test/java/com/postgraduate/domain/salary/presentation/SalaryControllerTest.java
@@ -60,7 +60,7 @@ class SalaryControllerTest extends IntegrationTest {
         Senior senior = new Senior(0L, user, "certification", Status.APPROVE, 0, info, profile, now(), now());
         seniorRepository.save(senior);
 
-        salary = new Salary(0L, false, senior, null, 0, SalaryUtil.getSalaryDate(), null, "bank", "account", "holder");
+        salary = new Salary(0L, false, senior, 0, SalaryUtil.getSalaryDate(), null, "bank", "account", "holder");
         salaryRepository.save(salary);
 
         token = jwtUtil.generateAccessToken(user.getUserId(), Role.SENIOR);

--- a/src/test/java/com/postgraduate/domain/senior/presentation/SeniorControllerTest.java
+++ b/src/test/java/com/postgraduate/domain/senior/presentation/SeniorControllerTest.java
@@ -216,7 +216,7 @@ class SeniorControllerTest extends IntegrationTest {
     @Test
     @DisplayName("대학원생 정산 계좌를 생성한다")
     void updateAccount() throws Exception {
-        Salary salary = new Salary(0L, false, senior, null, 10000, getSalaryDate(), now(), null, null, null);
+        Salary salary = new Salary(0L, false, senior, 10000, getSalaryDate(), now(), null, null, null);
         salaryRepository.save(salary);
 
         String request = objectMapper.writeValueAsString(
@@ -238,7 +238,7 @@ class SeniorControllerTest extends IntegrationTest {
     @WithMockUser(authorities = {"SENIOR"})
     @DisplayName("빈 정산 계좌를 입력으면 예외가 발생한다")
     void updateInvalidAccount(String empty) throws Exception {
-        Salary salary = new Salary(0L, false, senior, null, 10000, getSalaryDate(), now(), null, null, null);
+        Salary salary = new Salary(0L, false, senior, 10000, getSalaryDate(), now(), null, null, null);
         salaryRepository.save(salary);
 
         String request = objectMapper.writeValueAsString(
@@ -430,7 +430,7 @@ class SeniorControllerTest extends IntegrationTest {
     @Test
     @DisplayName("대학원생 마이페이지 계정을 설정한다")
     void updateSeniorUserAccount() throws Exception {
-        Salary salary = new Salary(0L, false, senior, null, 10000, getSalaryDate(), now(), null, null, null);
+        Salary salary = new Salary(0L, false, senior, 10000, getSalaryDate(), now(), null, null, null);
         salaryRepository.save(salary);
 
         String request = objectMapper.writeValueAsString(
@@ -452,7 +452,7 @@ class SeniorControllerTest extends IntegrationTest {
     @WithMockUser(authorities = {"SENIOR"})
     @DisplayName("대학원생 마이페이지 계정을 수정 요청에 닉네임, 전화번호, 프로필사진이 없다면 예외가 발생한다")
     void updateEmptySeniorUserAccount(String empty) throws Exception {
-        Salary salary = new Salary(0L, false, senior, null, 10000, getSalaryDate(), now(), null, null, null);
+        Salary salary = new Salary(0L, false, senior, 10000, getSalaryDate(), now(), null, null, null);
         salaryRepository.save(salary);
 
         String request = objectMapper.writeValueAsString(
@@ -475,7 +475,7 @@ class SeniorControllerTest extends IntegrationTest {
         Account account = new Account(0L, "accountNumber", "bank", "accountHolder", senior);
         accountRepository.save(account);
 
-        Salary salary = new Salary(0L, false, senior, null, 10000, getSalaryDate(), now(), null, null, null);
+        Salary salary = new Salary(0L, false, senior, 10000, getSalaryDate(), now(), null, null, null);
         salaryRepository.save(salary);
 
         String request = objectMapper.writeValueAsString(


### PR DESCRIPTION
## 🦝 PR 요약
Payment, Salary, Mentoring 관계 수정 및 결제 실패시 로직 수정

## ✨ PR 상세 내용
- Payment와 Salary 관계 제거
- Mentoring과 Salary 관계 추가
- Mentoring 완료시 Salary 업데이트 하도록 로직 수정
- 연관관계 수정에 따른 쿼리 수정 및 조회 로직 수정
- 결제 실패시 우선 정상 응답 후 멘토링 신청시 예외 출력하도록 변경

## 🚨 주의 사항
테이블 관계 수정에 따른 오류 유의
결제 실패에 대한 추가 확인 필요

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
