### PR TITLE
RAC-322 fix : 정산일 계산 수정

### DIFF
--- a/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryInfoUseCase.java
@@ -15,10 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.util.List;
-
-import static com.postgraduate.domain.salary.util.SalaryUtil.getSalaryDate;
 
 @Service
 @Transactional
@@ -30,10 +27,9 @@ public class SalaryInfoUseCase {
 
     public SalaryInfoResponse getSalary(User user) {
         Senior senior = seniorGetService.byUser(user);
-        LocalDate salaryDate = getSalaryDate();
         Salary salary = salaryGetService.bySenior(senior);
         int amount = salary.getTotalAmount();
-        return new SalaryInfoResponse(salaryDate, amount);
+        return new SalaryInfoResponse(salary.getSalaryDate(), amount);
     }
 
     public SalaryDetailsResponse getSalaryDetail(User user, Boolean status) {

--- a/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryManageUseCase.java
@@ -30,7 +30,7 @@ public class SalaryManageUseCase {
         slackSalaryMessage.sendSlackSalary(salaries);
 
         List<SeniorAndAccount> seniorAndAccounts = seniorGetService.findAllSeniorAndAccount();
-        LocalDate salaryDate = LocalDate.now().plusDays(7);
+        LocalDate salaryDate = LocalDate.now().plusDays(14);
         seniorAndAccounts.forEach(seniorAndAccount -> {
             Salary salary = SalaryMapper.mapToSalary(seniorAndAccount.senior(), salaryDate, seniorAndAccount.account());
             salarySaveService.save(salary);

--- a/src/main/java/com/postgraduate/domain/salary/util/SalaryUtil.java
+++ b/src/main/java/com/postgraduate/domain/salary/util/SalaryUtil.java
@@ -20,8 +20,8 @@ public class SalaryUtil {
         LocalDate now = LocalDate.now();
         DayOfWeek dayOfWeek = now.getDayOfWeek();
         return dayOfWeek.getValue() < SALARY_END_DATE
-                ? now.plusDays(7 + (dayOfWeek.getValue() - SALARY_DATE))
-                : now.plusDays(dayOfWeek.getValue() - SALARY_DATE);
+                ? now.plusDays(7 + (dayOfWeek.getValue() - SALARY_DATE) + 1)
+                : now.plusDays(dayOfWeek.getValue() - SALARY_DATE + 1);
     }
 
     public static SalaryStatus getStatus(Salary salary) {

--- a/src/main/java/com/postgraduate/domain/salary/util/SalaryUtil.java
+++ b/src/main/java/com/postgraduate/domain/salary/util/SalaryUtil.java
@@ -19,9 +19,9 @@ public class SalaryUtil {
     public static LocalDate getSalaryDate() {
         LocalDate now = LocalDate.now();
         DayOfWeek dayOfWeek = now.getDayOfWeek();
-        return dayOfWeek.getValue() < SALARY_END_DATE
-                ? now.plusDays(6 + (dayOfWeek.getValue() - SALARY_DATE))
-                : now.plusDays(SALARY_DATE);
+        return dayOfWeek.getValue() == SALARY_END_DATE
+                ? now.plusDays(7 + (SALARY_DATE - dayOfWeek.getValue()))
+                : now.plusDays(7 + SALARY_DATE);
     }
 
     public static SalaryStatus getStatus(Salary salary) {

--- a/src/main/java/com/postgraduate/domain/salary/util/SalaryUtil.java
+++ b/src/main/java/com/postgraduate/domain/salary/util/SalaryUtil.java
@@ -20,8 +20,8 @@ public class SalaryUtil {
         LocalDate now = LocalDate.now();
         DayOfWeek dayOfWeek = now.getDayOfWeek();
         return dayOfWeek.getValue() < SALARY_END_DATE
-                ? now.plusDays(7 + (dayOfWeek.getValue() - SALARY_DATE) + 1)
-                : now.plusDays(dayOfWeek.getValue() - SALARY_DATE + 1);
+                ? now.plusDays(6 + (dayOfWeek.getValue() - SALARY_DATE))
+                : now.plusDays(SALARY_DATE);
     }
 
     public static SalaryStatus getStatus(Salary salary) {


### PR DESCRIPTION
## 🦝 PR 요약
정산일 계산 수정

## ✨ PR 상세 내용
정산일 계산 로직이 잘못되어 해당 부분 수정
일~토 멘토링건 돌아오는 주 목요일 정산
이번주 목요일에 다다음주 목요일 정산값 생성 (이번주 목요일에 저번주 정산 수행하고, 이번주 멘토링은 다음주 정산에 들어가기 때문에 다음주 정산은 저번주에 만들어져 있어야 함)

## 🚨 주의 사항
sonarCloud의 경고가 있지만, long으로 형변환은 불필요한 형변환으로 판단하여 따르지 않음 (코드게이트 fail가능성) 다만 무시하겠음

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
