### PR TITLE
RAC-326 fix : 선후배 멘토링 상세보기 오류 수정

### DIFF
--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseCase.java
@@ -123,20 +123,20 @@ public class MentoringManageUseCase {
         Optional<Account> account = accountGetService.bySenior(senior);
         return account.isPresent();
     }
-    
+
     @Scheduled(cron = "0 59 23 * * *", zone = "Asia/Seoul")
     public void updateAutoCancel() {
         LocalDateTime now = LocalDateTime.now()
                 .toLocalDate()
                 .atStartOfDay();
-        List<Mentoring> waitingMentorings = mentoringGetService.byStatusAndCreatedAt(WAITING, now);
+        List<Mentoring> waitingMentorings = mentoringGetService.byWaitingAndCreatedAt(now);
         waitingMentorings.forEach(mentoringRenewalUseCase::updateCancelWithAuto);
         //TODO : 알림 보내거나 나머지 작업
     }
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void updateAutoDone() {
-        List<Mentoring> expectedMentorings = mentoringGetService.byStatus(EXPECTED);
+        List<Mentoring> expectedMentorings = mentoringGetService.byExpected();
         expectedMentorings.stream()
                 .filter(mentoring -> {
                     try {

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCase.java
@@ -16,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static com.postgraduate.domain.mentoring.application.mapper.MentoringMapper.mapToAppliedDetailInfo;
-import static com.postgraduate.domain.mentoring.domain.entity.constant.Status.*;
 
 @Service
 @Transactional
@@ -25,14 +24,12 @@ public class MentoringUserInfoUseCase {
     private final MentoringGetService mentoringGetService;
 
     public AppliedMentoringDetailResponse getMentoringDetail(User user, Long mentoringId) {
-        Mentoring mentoring = mentoringGetService.byMentoringId(mentoringId);
-        mentoring.checkIsMineWithUser(user);
-        mentoring.checkDetailCondition();
+        Mentoring mentoring = mentoringGetService.byIdAndUserForDetails(mentoringId, user);
         return mapToAppliedDetailInfo(mentoring);
     }
 
     public AppliedMentoringResponse getWaiting(User user) {
-        List<Mentoring> mentorings = mentoringGetService.byUser(user, WAITING);
+        List<Mentoring> mentorings = mentoringGetService.byUserWaiting(user);
         List<WaitingMentoringInfo> waitingMentoringInfos = mentorings.stream()
                 .map(MentoringMapper::mapToWaitingInfo)
                 .toList();
@@ -40,7 +37,7 @@ public class MentoringUserInfoUseCase {
     }
 
     public AppliedMentoringResponse getExpected(User user) {
-        List<Mentoring> mentorings = mentoringGetService.byUser(user, EXPECTED);
+        List<Mentoring> mentorings = mentoringGetService.byUserExpected(user);
         List<ExpectedMentoringInfo> expectedMentoringInfos = mentorings.stream()
                 .map(MentoringMapper::mapToExpectedInfo)
                 .toList();
@@ -48,7 +45,7 @@ public class MentoringUserInfoUseCase {
     }
 
     public AppliedMentoringResponse getDone(User user) {
-        List<Mentoring> mentorings = mentoringGetService.byUser(user, DONE);
+        List<Mentoring> mentorings = mentoringGetService.byUserDone(user);
         List<DoneMentoringInfo> doneMentoringInfos = mentorings.stream()
                 .map(MentoringMapper::mapToDoneInfo)
                 .toList();

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/entity/Mentoring.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/entity/Mentoring.java
@@ -1,10 +1,6 @@
 package com.postgraduate.domain.mentoring.domain.entity;
 
-import com.postgraduate.domain.auth.exception.PermissionDeniedException;
 import com.postgraduate.domain.mentoring.domain.entity.constant.Status;
-import com.postgraduate.domain.mentoring.exception.MentoringDetailNotFoundException;
-import com.postgraduate.domain.mentoring.exception.MentoringNotExpectedException;
-import com.postgraduate.domain.mentoring.exception.MentoringNotWaitingException;
 import com.postgraduate.domain.payment.domain.entity.Payment;
 import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.senior.domain.entity.Senior;
@@ -21,7 +17,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-import static com.postgraduate.domain.mentoring.domain.entity.constant.Status.*;
+import static com.postgraduate.domain.mentoring.domain.entity.constant.Status.WAITING;
 import static java.time.LocalDateTime.now;
 import static java.time.LocalDateTime.parse;
 import static java.time.format.DateTimeFormatter.ofPattern;
@@ -82,40 +78,6 @@ public class Mentoring {
 
     public void updateDate(String date) {
         this.date = date;
-    }
-
-    public boolean checkIsWaiting() {
-        if (this.status == WAITING)
-            return true;
-        throw new MentoringNotWaitingException();
-    }
-
-    public boolean checkIsExpected() {
-        if (this.status == EXPECTED)
-            return true;
-        throw new MentoringNotExpectedException();
-    }
-
-    public boolean checkDetailCondition() {
-        if (this.status == WAITING || this.status == EXPECTED)
-            return true;
-        throw new MentoringDetailNotFoundException();
-    }
-
-    public boolean checkIsMineWithUser(User user) {
-        if (this.user.equals(user))
-            return true;
-        log.error("userId = {}", user.getUserId());
-        log.error("mentoring.getUserId = {}", this.user.getUserId());
-        throw new PermissionDeniedException();
-    }
-
-    public boolean checkIsMineWithSenior(Senior senior) {
-        if (this.senior.equals(senior))
-            return true;
-        log.error("senior = {}", senior.getSeniorId());
-        log.error("mentoring.getSeniorId = {}", this.senior.getSeniorId());
-        throw new PermissionDeniedException();
     }
 
     public boolean checkAutoDone() {

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringDslRepository.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringDslRepository.java
@@ -14,15 +14,13 @@ import java.util.Optional;
 public interface MentoringDslRepository {
     List<Mentoring> findAllBySeniorId(Long seniorId);
     List<Mentoring> findAllBySeniorAndStatus(Senior senior, Status status);
-    List<Mentoring> findAllBySeniorAndDone(Senior inputSenior);
     List<Mentoring> findAllByUserId(Long userId);
     List<Mentoring> findAllByUserAndStatus(User user, Status status);
     Optional<Mentoring> findByMentoringId(Long mentoringId);
     List<Mentoring> findAllBySeniorAndSalaryStatus(Senior senior, Boolean status);
-
     Page<Mentoring> findAllBySearchPayment(String search, Pageable pageable);
-
     List<Mentoring> findAllByStatusAndCreatedAtIsBefore(Status status, LocalDateTime now);
-
     List<Mentoring> findAllByStatus(Status status);
+    Optional<Mentoring> findByMentoringIdAndUserForDetails(Long mentoringId, User user);
+    Optional<Mentoring> findByMentoringIdAndSeniorForDetails(Long mentoringId, Senior senior);
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringDslRepositoryImpl.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringDslRepositoryImpl.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.postgraduate.domain.mentoring.domain.entity.QMentoring.mentoring;
+import static com.postgraduate.domain.mentoring.domain.entity.constant.Status.EXPECTED;
+import static com.postgraduate.domain.mentoring.domain.entity.constant.Status.WAITING;
 import static com.postgraduate.domain.payment.domain.entity.QPayment.payment;
 import static com.postgraduate.domain.salary.domain.entity.QSalary.salary;
 import static com.postgraduate.domain.senior.domain.entity.QSenior.senior;
@@ -49,19 +51,6 @@ public class MentoringDslRepositoryImpl implements MentoringDslRepository {
                 .join(mentoring.user, user)
                 .fetchJoin()
                 .where(mentoring.senior.eq(inputSenior), mentoring.status.eq(status))
-                .orderBy(mentoring.createdAt.desc())
-                .fetch();
-    }
-
-    @Override
-    public List<Mentoring> findAllBySeniorAndDone(Senior inputSenior) {
-        return queryFactory.selectFrom(mentoring)
-                .distinct()
-                .join(mentoring.user, user)
-                .fetchJoin()
-                .join(mentoring.payment, payment)
-                .fetchJoin()
-                .where(mentoring.senior.eq(inputSenior), mentoring.status.eq(Status.DONE))
                 .orderBy(mentoring.createdAt.desc())
                 .fetch();
     }
@@ -100,7 +89,7 @@ public class MentoringDslRepositoryImpl implements MentoringDslRepository {
                 .fetchJoin()
                 .leftJoin(mentoring.user, user)
                 .fetchJoin()
-                .where(mentoring.mentoringId.eq(mentoringId), mentoring.user.isDelete.isFalse(), mentoring.senior.user.isDelete.isFalse())
+                .where(mentoring.mentoringId.eq(mentoringId))
                 .fetchOne());
     }
 
@@ -179,5 +168,35 @@ public class MentoringDslRepositoryImpl implements MentoringDslRepository {
                 .fetchJoin()
                 .where(mentoring.status.eq(status))
                 .fetch();
+    }
+
+    @Override
+    public Optional<Mentoring> findByMentoringIdAndUserForDetails(Long mentoringId, User user) {
+        return Optional.ofNullable(queryFactory.selectFrom(mentoring)
+                .where(
+                        mentoring.user.eq(user)
+                                .and(mentoring.mentoringId.eq(mentoringId))
+                                .and(
+                                        mentoring.status.eq(WAITING)
+                                                .or(mentoring.status.eq(EXPECTED))
+                                )
+                )
+                .fetchOne()
+        );
+    }
+
+    @Override
+    public Optional<Mentoring> findByMentoringIdAndSeniorForDetails(Long mentoringId, Senior senior) {
+        return Optional.ofNullable(queryFactory.selectFrom(mentoring)
+                .where(
+                        mentoring.senior.eq(senior)
+                                .and(mentoring.mentoringId.eq(mentoringId))
+                                .and(
+                                        mentoring.status.eq(WAITING)
+                                                .or(mentoring.status.eq(EXPECTED))
+                                )
+                )
+                .fetchOne()
+        );
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/repository/MentoringRepository.java
@@ -1,11 +1,16 @@
 package com.postgraduate.domain.mentoring.domain.repository;
 
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
+import com.postgraduate.domain.mentoring.domain.entity.constant.Status;
 import com.postgraduate.domain.payment.domain.entity.Payment;
+import com.postgraduate.domain.senior.domain.entity.Senior;
+import com.postgraduate.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface MentoringRepository extends JpaRepository<Mentoring, Long>, MentoringDslRepository {
     Optional<Mentoring> findByPayment(Payment payment);
+    Optional<Mentoring> findByMentoringIdAndUserAndStatus(Long mentoringId, User user, Status status);
+    Optional<Mentoring> findByMentoringIdAndSeniorAndStatus(Long mentoringId, Senior senior, Status status);
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
@@ -97,12 +97,12 @@ public class MentoringGetService {
                 .orElseThrow(MentoringNotFoundException::new);
     }
 
-    public List<Mentoring> byStatusAndCreatedAt(Status status, LocalDateTime now) {
-        return mentoringRepository.findAllByStatusAndCreatedAtIsBefore(status, now);
+    public List<Mentoring> byWaitingAndCreatedAt(LocalDateTime now) {
+        return mentoringRepository.findAllByStatusAndCreatedAtIsBefore(WAITING, now);
     }
 
-    public List<Mentoring> byStatus(Status status) {
-        return mentoringRepository.findAllByStatus(status);
+    public List<Mentoring> byExpected() {
+        return mentoringRepository.findAllByStatus(EXPECTED);
     }
 
     public List<Mentoring> byUserId(Long userId) {

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
@@ -82,13 +82,38 @@ public class MentoringGetService {
                 .orElseThrow(MentoringNotFoundException::new);
     }
 
-    public Mentoring byIdAndUserAndStatus(Long mentoringId, User user, Status status) {
-        return mentoringRepository.findByMentoringIdAndUserAndStatus(mentoringId, user, status)
+    public Mentoring byIdAndUserAndWaiting(Long mentoringId, User user) {
+        return mentoringRepository.findByMentoringIdAndUserAndStatus(mentoringId, user, WAITING)
+                .orElseThrow(MentoringNotFoundException::new);
+    }
+
+    public Mentoring byIdAndUserAndExpected(Long mentoringId, User user) {
+        return mentoringRepository.findByMentoringIdAndUserAndStatus(mentoringId, user, EXPECTED)
+                .orElseThrow(MentoringNotFoundException::new);
+    }
+
+    public Mentoring byIdAndUserAndDone(Long mentoringId, User user) {
+        return mentoringRepository.findByMentoringIdAndUserAndStatus(mentoringId, user, DONE)
                 .orElseThrow(MentoringNotFoundException::new);
     }
 
     public Mentoring byIdAndSeniorAndStatus(Long mentoringId, Senior senior, Status status) {
         return mentoringRepository.findByMentoringIdAndSeniorAndStatus(mentoringId, senior, status)
+                .orElseThrow(MentoringNotFoundException::new);
+    }
+
+    public Mentoring byIdAndSeniorAndWaiting(Long mentoringId, Senior senior) {
+        return mentoringRepository.findByMentoringIdAndSeniorAndStatus(mentoringId, senior, WAITING)
+                .orElseThrow(MentoringNotFoundException::new);
+    }
+
+    public Mentoring byIdAndSeniorAndExpected(Long mentoringId, Senior senior) {
+        return mentoringRepository.findByMentoringIdAndSeniorAndStatus(mentoringId, senior, EXPECTED)
+                .orElseThrow(MentoringNotFoundException::new);
+    }
+
+    public Mentoring byIdAndSeniorAndDone(Long mentoringId, Senior senior) {
+        return mentoringRepository.findByMentoringIdAndSeniorAndStatus(mentoringId, senior, DONE)
                 .orElseThrow(MentoringNotFoundException::new);
     }
 

--- a/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/domain/service/MentoringGetService.java
@@ -17,6 +17,8 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.postgraduate.domain.mentoring.domain.entity.constant.Status.*;
+
 @Service
 @RequiredArgsConstructor
 public class MentoringGetService {
@@ -41,20 +43,52 @@ public class MentoringGetService {
                 .orElseThrow(MentoringNotFoundException::new);
     }
 
-    public List<Mentoring> byUser(User user, Status status) {
-        return mentoringRepository.findAllByUserAndStatus(user, status);
+    public List<Mentoring> byUserWaiting(User user) {
+        return mentoringRepository.findAllByUserAndStatus(user, WAITING);
     }
 
-    public List<Mentoring> bySenior(Senior senior, Status status) {
-        return mentoringRepository.findAllBySeniorAndStatus(senior, status);
+    public List<Mentoring> byUserExpected(User user) {
+        return mentoringRepository.findAllByUserAndStatus(user, EXPECTED);
     }
 
-    public List<Mentoring> bySenior(Senior senior) {
-        return mentoringRepository.findAllBySeniorAndDone(senior);
+    public List<Mentoring> byUserDone(User user) {
+        return mentoringRepository.findAllByUserAndStatus(user, DONE);
+    }
+
+    public List<Mentoring> bySeniorWaiting(Senior senior) {
+        return mentoringRepository.findAllBySeniorAndStatus(senior, WAITING);
+    }
+
+    public List<Mentoring> bySeniorExpected(Senior senior) {
+        return mentoringRepository.findAllBySeniorAndStatus(senior, EXPECTED);
+    }
+
+    public List<Mentoring> bySeniorDone(Senior senior) {
+        return mentoringRepository.findAllBySeniorAndStatus(senior, DONE);
     }
 
     public Mentoring byMentoringId(Long mentoringId) {
         return mentoringRepository.findByMentoringId(mentoringId)
+                .orElseThrow(MentoringNotFoundException::new);
+    }
+
+    public Mentoring byIdAndUserForDetails(Long mentoringId, User user) {
+        return mentoringRepository.findByMentoringIdAndUserForDetails(mentoringId, user)
+                .orElseThrow(MentoringNotFoundException::new);
+    }
+
+    public Mentoring byIdAndStatusForDetails(Long mentoringId, Senior senior) {
+        return mentoringRepository.findByMentoringIdAndSeniorForDetails(mentoringId, senior)
+                .orElseThrow(MentoringNotFoundException::new);
+    }
+
+    public Mentoring byIdAndUserAndStatus(Long mentoringId, User user, Status status) {
+        return mentoringRepository.findByMentoringIdAndUserAndStatus(mentoringId, user, status)
+                .orElseThrow(MentoringNotFoundException::new);
+    }
+
+    public Mentoring byIdAndSeniorAndStatus(Long mentoringId, Senior senior, Status status) {
+        return mentoringRepository.findByMentoringIdAndSeniorAndStatus(mentoringId, senior, status)
                 .orElseThrow(MentoringNotFoundException::new);
     }
 

--- a/src/main/java/com/postgraduate/domain/mentoring/presentation/MentoringController.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/presentation/MentoringController.java
@@ -57,14 +57,6 @@ public class MentoringController {
         return ResponseDto.create(MENTORING_FIND.getCode(), GET_MENTORING_DETAIL_INFO.getMessage(), mentoringDetail);
     }
 
-    @DeleteMapping("/me/{mentoringId}")
-    @Operation(summary = "[대학생] 결제 오류/취소시 멘토링 삭제", description = "대학생이 신청한 멘토링을 삭제합니다. (취소/거절 아닌 삭제)")
-    public ResponseDto<AppliedMentoringDetailResponse> deleteMentoring(@AuthenticationPrincipal User user,
-                                                                       @PathVariable Long mentoringId) {
-        manageUseCase.delete(user, mentoringId);
-        return ResponseDto.create(MENTORING_DELETE.getCode(), DELETE_MENTORING.getMessage());
-    }
-
     @PostMapping("/applying")
     @Operation(summary = "[대학생] 멘토링 신청", description = "대학생이 멘토링을 신청합니다.")
     public ResponseDto<ApplyingResponse> applyForMentoringWithPayment(@AuthenticationPrincipal User user, @RequestBody MentoringApplyRequest request) {

--- a/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCaseTest.java
@@ -4,6 +4,7 @@ import com.postgraduate.domain.mentoring.application.dto.res.SeniorMentoringResp
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.mentoring.domain.service.MentoringGetService;
 import com.postgraduate.domain.mentoring.exception.MentoringDetailNotFoundException;
+import com.postgraduate.domain.mentoring.exception.MentoringNotFoundException;
 import com.postgraduate.domain.payment.domain.entity.Payment;
 import com.postgraduate.domain.payment.domain.entity.constant.Status;
 import com.postgraduate.domain.salary.domain.entity.Salary;
@@ -57,7 +58,7 @@ class MentoringSeniorInfoUseCaseTest {
 
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
-        given(mentoringGetService.byMentoringId(any()))
+        given(mentoringGetService.byIdAndStatusForDetails(mentoringId, senior))
                 .willReturn(mentoring);
 
         assertThat(mentoringSeniorInfoUseCase.getSeniorMentoringDetail(user, mentoringId))
@@ -79,11 +80,11 @@ class MentoringSeniorInfoUseCaseTest {
 
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
-        given(mentoringGetService.byMentoringId(any()))
-                .willReturn(mentoring);
+        given(mentoringGetService.byIdAndStatusForDetails(mentoringId, senior))
+                .willThrow(MentoringNotFoundException.class);
 
         assertThatThrownBy(() -> mentoringSeniorInfoUseCase.getSeniorMentoringDetail(user, mentoringId))
-                .isInstanceOf(MentoringDetailNotFoundException.class);
+                .isInstanceOf(MentoringNotFoundException.class);
     }
 
     @Test
@@ -101,11 +102,11 @@ class MentoringSeniorInfoUseCaseTest {
 
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
-        given(mentoringGetService.byMentoringId(any()))
-                .willReturn(mentoring);
+        given(mentoringGetService.byIdAndStatusForDetails(mentoringId, senior))
+                .willThrow(MentoringNotFoundException.class);
 
         assertThatThrownBy(() -> mentoringSeniorInfoUseCase.getSeniorMentoringDetail(user, mentoringId))
-                .isInstanceOf(MentoringDetailNotFoundException.class);
+                .isInstanceOf(MentoringNotFoundException.class);
     }
 
     @Test
@@ -123,11 +124,11 @@ class MentoringSeniorInfoUseCaseTest {
 
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
-        given(mentoringGetService.byMentoringId(any()))
-                .willReturn(mentoring);
+        given(mentoringGetService.byIdAndStatusForDetails(mentoringId, senior))
+                .willThrow(MentoringNotFoundException.class);
 
         assertThatThrownBy(() -> mentoringSeniorInfoUseCase.getSeniorMentoringDetail(user, mentoringId))
-                .isInstanceOf(MentoringDetailNotFoundException.class);
+                .isInstanceOf(MentoringNotFoundException.class);
     }
 
     @Test
@@ -144,7 +145,7 @@ class MentoringSeniorInfoUseCaseTest {
 
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
-        given(mentoringGetService.bySenior(senior, WAITING))
+        given(mentoringGetService.bySeniorWaiting(senior))
                 .willReturn(mentorings);
 
         SeniorMentoringResponse seniorWaiting = mentoringSeniorInfoUseCase.getSeniorWaiting(user);
@@ -167,7 +168,7 @@ class MentoringSeniorInfoUseCaseTest {
 
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
-        given(mentoringGetService.bySenior(senior, EXPECTED))
+        given(mentoringGetService.bySeniorExpected(senior))
                 .willReturn(mentorings);
 
         SeniorMentoringResponse seniorExpected = mentoringSeniorInfoUseCase.getSeniorExpected(user);
@@ -194,7 +195,7 @@ class MentoringSeniorInfoUseCaseTest {
 
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
-        given(mentoringGetService.bySenior(senior))
+        given(mentoringGetService.bySeniorDone(senior))
                 .willReturn(mentorings);
 
         SeniorMentoringResponse seniorDone = mentoringSeniorInfoUseCase.getSeniorDone(user);

--- a/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCaseTest.java
@@ -4,6 +4,7 @@ import com.postgraduate.domain.mentoring.application.dto.res.AppliedMentoringRes
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.mentoring.domain.service.MentoringGetService;
 import com.postgraduate.domain.mentoring.exception.MentoringDetailNotFoundException;
+import com.postgraduate.domain.mentoring.exception.MentoringNotFoundException;
 import com.postgraduate.domain.payment.domain.entity.Payment;
 import com.postgraduate.domain.senior.domain.entity.Info;
 import com.postgraduate.domain.senior.domain.entity.Profile;
@@ -67,7 +68,7 @@ class MentoringUserInfoUseCaseTest {
                 , 40, EXPECTED
                 , LocalDateTime.now(), LocalDateTime.now());
 
-        given(mentoringGetService.byMentoringId(any()))
+        given(mentoringGetService.byIdAndUserForDetails(mentoringId, user))
                 .willReturn(mentoring);
 
         assertThat(mentoringUserInfoUseCase.getMentoringDetail(user, mentoringId))
@@ -84,11 +85,11 @@ class MentoringUserInfoUseCaseTest {
                 , 40, DONE
                 , LocalDateTime.now(), LocalDateTime.now());
 
-        given(mentoringGetService.byMentoringId(any()))
-                .willReturn(mentoring);
+        given(mentoringGetService.byIdAndUserForDetails(mentoringId, user))
+                .willThrow(MentoringNotFoundException.class);
 
         assertThatThrownBy(() -> mentoringUserInfoUseCase.getMentoringDetail(user, mentoringId))
-                .isInstanceOf(MentoringDetailNotFoundException.class);
+                .isInstanceOf(MentoringNotFoundException.class);
     }
 
     @Test
@@ -101,11 +102,11 @@ class MentoringUserInfoUseCaseTest {
                 , 40, REFUSE
                 , LocalDateTime.now(), LocalDateTime.now());
 
-        given(mentoringGetService.byMentoringId(any()))
-                .willReturn(mentoring);
+        given(mentoringGetService.byIdAndUserForDetails(mentoringId, user))
+                .willThrow(MentoringNotFoundException.class);
 
         assertThatThrownBy(() -> mentoringUserInfoUseCase.getMentoringDetail(user, mentoringId))
-                .isInstanceOf(MentoringDetailNotFoundException.class);
+                .isInstanceOf(MentoringNotFoundException.class);
     }
 
     @Test
@@ -118,11 +119,11 @@ class MentoringUserInfoUseCaseTest {
                 , 40, CANCEL
                 , LocalDateTime.now(), LocalDateTime.now());
 
-        given(mentoringGetService.byMentoringId(any()))
-                .willReturn(mentoring);
+        given(mentoringGetService.byIdAndUserForDetails(mentoringId, user))
+                .willThrow(MentoringNotFoundException.class);
 
         assertThatThrownBy(() -> mentoringUserInfoUseCase.getMentoringDetail(user, mentoringId))
-                .isInstanceOf(MentoringDetailNotFoundException.class);
+                .isInstanceOf(MentoringNotFoundException.class);
     }
 
     @Test
@@ -146,7 +147,7 @@ class MentoringUserInfoUseCaseTest {
                 , LocalDateTime.now(), LocalDateTime.now());
         List<Mentoring> mentorings = List.of(mentoring1, mentoring2, mentoring3);
 
-        given(mentoringGetService.byUser(user, WAITING))
+        given(mentoringGetService.byUserWaiting(user))
                 .willReturn(mentorings);
 
         AppliedMentoringResponse waiting = mentoringUserInfoUseCase.getWaiting(user);
@@ -176,7 +177,7 @@ class MentoringUserInfoUseCaseTest {
                 , LocalDateTime.now(), LocalDateTime.now());
         List<Mentoring> mentorings = List.of(mentoring1, mentoring2, mentoring3);
 
-        given(mentoringGetService.byUser(user, EXPECTED))
+        given(mentoringGetService.byUserExpected(user))
                 .willReturn(mentorings);
 
         AppliedMentoringResponse expected = mentoringUserInfoUseCase.getExpected(user);
@@ -206,7 +207,7 @@ class MentoringUserInfoUseCaseTest {
                 , LocalDateTime.now(), LocalDateTime.now());
         List<Mentoring> mentorings = List.of(mentoring1, mentoring2, mentoring3);
 
-        given(mentoringGetService.byUser(user, DONE))
+        given(mentoringGetService.byUserDone(user))
                 .willReturn(mentorings);
 
         AppliedMentoringResponse done = mentoringUserInfoUseCase.getDone(user);

--- a/src/test/java/com/postgraduate/domain/mentoring/presentation/MentoringControllerTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/presentation/MentoringControllerTest.java
@@ -158,8 +158,8 @@ class MentoringControllerTest extends IntegrationTest {
         mvc.perform(get("/mentoring/me/{mentoringId}", mentoring.getMentoringId())
                         .header(AUTHORIZATION, BEARER + userAccessToken))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(AUTH_DENIED.getCode()))
-                .andExpect(jsonPath("$.message").value(PERMISSION_DENIED.getMessage()));
+                .andExpect(jsonPath("$.code").value(MENTORING_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(NOT_FOUND_MENTORING.getMessage()));
     }
 
 
@@ -173,8 +173,8 @@ class MentoringControllerTest extends IntegrationTest {
         mvc.perform(get("/mentoring/me/{mentoringId}", mentoring.getMentoringId())
                         .header(AUTHORIZATION, BEARER + userAccessToken))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(DETAIL_NOT_FOUND.getCode()))
-                .andExpect(jsonPath("$.message").value(NOT_FOUND_DETAIL.getMessage()));
+                .andExpect(jsonPath("$.code").value(MENTORING_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(NOT_FOUND_MENTORING.getMessage()));
     }
 
 //    @Test
@@ -253,8 +253,8 @@ class MentoringControllerTest extends IntegrationTest {
         mvc.perform(patch("/mentoring/me/{mentoringId}/done", mentoring.getMentoringId())
                         .header(AUTHORIZATION, BEARER + userAccessToken))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(MENTORING_NOT_EXPECTED.getCode()))
-                .andExpect(jsonPath("$.message").value(NOT_EXPECTED_MENTORING.getMessage()));
+                .andExpect(jsonPath("$.code").value(MENTORING_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(NOT_FOUND_MENTORING.getMessage()));
     }
 
 //    @Test
@@ -281,8 +281,8 @@ class MentoringControllerTest extends IntegrationTest {
         mvc.perform(patch("/mentoring/me/{mentoringId}/cancel", mentoring.getMentoringId())
                         .header(AUTHORIZATION, BEARER + userAccessToken))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(MENTORING_NOT_WAITING.getCode()))
-                .andExpect(jsonPath("$.message").value(NOT_WAITING_MENTORING.getMessage()));
+                .andExpect(jsonPath("$.code").value(MENTORING_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(NOT_FOUND_MENTORING.getMessage()));
     }
 
     @ParameterizedTest
@@ -346,8 +346,8 @@ class MentoringControllerTest extends IntegrationTest {
         mvc.perform(get("/mentoring/senior/me/{mentoringId}", mentoring.getMentoringId())
                         .header(AUTHORIZATION, BEARER + seniorAccessToken))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(DETAIL_NOT_FOUND.getCode()))
-                .andExpect(jsonPath("$.message").value(NOT_FOUND_DETAIL.getMessage()));
+                .andExpect(jsonPath("$.code").value(MENTORING_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(NOT_FOUND_MENTORING.getMessage()));
     }
 
     @Test
@@ -381,7 +381,8 @@ class MentoringControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(MENTORING_NOT_WAITING.getCode()));
+                .andExpect(jsonPath("$.code").value(MENTORING_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(NOT_FOUND_MENTORING.getMessage()));
     }
 
     @ParameterizedTest
@@ -433,7 +434,8 @@ class MentoringControllerTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(MENTORING_NOT_WAITING.getCode()));
+                .andExpect(jsonPath("$.code").value(MENTORING_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(NOT_FOUND_MENTORING.getMessage()));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## 🦝 PR 요약
선후배 멘토링 상세보기 오류 수정

## ✨ PR 상세 내용
- 선배, 후배 멘토링 상세보기 권한 오류 수정
- 쿼리 수정 및 메소드 분리
- 기존 테스트 코드 수정

## 🚨 주의 사항
테스트 코드를 전체적으로 아예 손봐야 할 것 같음
이전에 테스트코드를 작성할 때 로직과 현재 로직이 다른 점이 많고, 메소드 자체가 삭제되고 추가된 것이 많아서 전체적인 변경이 필요할 것 같음!

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
