### PR TITLE
RAC-336 fix : 비즈뿌리오 토큰 발급 로직 수정

### DIFF
--- a/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioJuniorMessage.java
+++ b/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioJuniorMessage.java
@@ -3,7 +3,6 @@ package com.postgraduate.global.bizppurio.usecase;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.global.bizppurio.dto.req.CommonRequest;
-import com.postgraduate.global.bizppurio.dto.res.BizppurioTokenResponse;
 import com.postgraduate.global.bizppurio.dto.res.MessageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,11 +46,11 @@ public class BizppurioJuniorMessage {
 
     private void sendMessage(CommonRequest commonRequest) {
         try {
-            BizppurioTokenResponse tokenResponse = bizppurioAuth.getAuth();
+            String accessToken = bizppurioAuth.getAuth();
             webClient.post()
                     .uri(messageUrl)
                     .headers(h -> h.setContentType(APPLICATION_JSON))
-                    .headers(h -> h.setBearerAuth(tokenResponse.accesstoken()))
+                    .headers(h -> h.setBearerAuth(accessToken))
                     .bodyValue(commonRequest)
                     .retrieve()
                     .bodyToMono(MessageResponse.class)

--- a/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioSeniorMessage.java
+++ b/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioSeniorMessage.java
@@ -3,7 +3,6 @@ package com.postgraduate.global.bizppurio.usecase;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.global.bizppurio.dto.req.CommonRequest;
-import com.postgraduate.global.bizppurio.dto.res.BizppurioTokenResponse;
 import com.postgraduate.global.bizppurio.dto.res.MessageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,11 +57,11 @@ public class BizppurioSeniorMessage {
 
     private void sendMessage(CommonRequest commonRequest) {
         try {
-            BizppurioTokenResponse tokenResponse = bizppurioAuth.getAuth();
+            String accessToken = bizppurioAuth.getAuth();
             webClient.post()
                     .uri(messageUrl)
                     .headers(h -> h.setContentType(APPLICATION_JSON))
-                    .headers(h -> h.setBearerAuth(tokenResponse.accesstoken()))
+                    .headers(h -> h.setBearerAuth(accessToken))
                     .bodyValue(commonRequest)
                     .retrieve()
                     .bodyToMono(MessageResponse.class)


### PR DESCRIPTION
## 🦝 PR 요약
비즈뿌리오 토큰 발급 로직 수정

## ✨ PR 상세 내용
- Base64 encoding과정이 의도와 다르게 진행되는 부분 수정
- Redis에 토큰 저장 후 만료되는 경우에만 새롭게 토큰을 발급받아 사용하도록 수정

## 🚨 주의 사항
주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
