### PR TITLE
RAC-341 HotFix : 정산 자동 생성 관련 오류 수정

### DIFF
--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
@@ -65,7 +65,9 @@ public class SignUpUseCase {
         Senior senior = SeniorMapper.mapToSenior(user, request);
         seniorSaveService.saveSenior(senior);
         Salary salary = SalaryMapper.mapToSalary(senior, getSalaryDate());
+        Salary nextSalary = SalaryMapper.mapToSalary(senior, getSalaryDate().plusDays(7));
         salarySaveService.save(salary);
+        salarySaveService.save(nextSalary);
         slackSignUpMessage.sendSeniorSignUp(senior);
         bizppurioSeniorMessage.signUp(user);
         return senior.getUser();
@@ -78,7 +80,9 @@ public class SignUpUseCase {
         user = userGetService.byUserId(user.getUserId());
         userUpdateService.userToSeniorRole(user);
         Salary salary = SalaryMapper.mapToSalary(senior, getSalaryDate());
+        Salary nextSalary = SalaryMapper.mapToSalary(senior, getSalaryDate().plusDays(7));
         salarySaveService.save(salary);
+        salarySaveService.save(nextSalary);
         slackSignUpMessage.sendSeniorSignUp(senior);
         bizppurioSeniorMessage.signUp(user);
         return user;

--- a/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryManageUseCase.java
@@ -29,8 +29,8 @@ public class SalaryManageUseCase {
 
         List<SeniorAndAccount> seniorAndAccounts = seniorGetService.findAllSeniorAndAccount();
         LocalDate salaryDate = getSalaryDate().plusDays(7);
-        seniorAndAccounts.forEach(
-                seniorAndAccount -> salaryRenewalUseCase.createSalaryWithAuto(seniorAndAccount, salaryDate)
-        );
+        seniorAndAccounts.stream()
+                .filter(seniorAndAccount -> salaryGetService.bySeniorOptional(seniorAndAccount.senior(), salaryDate).isEmpty())
+                .forEach(seniorAndAccount -> salaryRenewalUseCase.createSalaryWithAuto(seniorAndAccount, salaryDate));
     }
 }

--- a/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryManageUseCase.java
@@ -22,7 +22,8 @@ public class SalaryManageUseCase {
     private final SlackSalaryMessage slackSalaryMessage;
     private final SalaryRenewalUseCase salaryRenewalUseCase;
 
-    @Scheduled(cron = "0 0 0 * * 4", zone = "Asia/Seoul")
+//    @Scheduled(cron = "0 0 0 * * 4", zone = "Asia/Seoul")
+    @Scheduled(fixedDelay = 1000000)
     public void createSalary() {
         List<Salary> salaries = salaryGetService.findAllLast();
         slackSalaryMessage.sendSlackSalary(salaries);

--- a/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/salary/application/usecase/SalaryManageUseCase.java
@@ -22,8 +22,7 @@ public class SalaryManageUseCase {
     private final SlackSalaryMessage slackSalaryMessage;
     private final SalaryRenewalUseCase salaryRenewalUseCase;
 
-//    @Scheduled(cron = "0 0 0 * * 4", zone = "Asia/Seoul")
-    @Scheduled(fixedDelay = 1000000)
+    @Scheduled(cron = "0 0 0 * * 4", zone = "Asia/Seoul")
     public void createSalary() {
         List<Salary> salaries = salaryGetService.findAllLast();
         slackSalaryMessage.sendSlackSalary(salaries);

--- a/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryGetService.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/service/SalaryGetService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -39,6 +40,10 @@ public class SalaryGetService {
         LocalDate salaryDate = SalaryUtil.getSalaryDate();
         return salaryRepository.findBySeniorAndSalaryDate(senior, salaryDate)
                 .orElseThrow(SalaryNotFoundException::new);
+    }
+
+    public Optional<Salary> bySeniorOptional(Senior senior, LocalDate salaryDate) {
+        return salaryRepository.findBySeniorAndSalaryDate(senior, salaryDate);
     }
 
     public List<Salary> allBySeniorAndAccountIsNull(Senior senior) {


### PR DESCRIPTION
## 🦝 PR 요약
정산 자동 생성 관련 오류 수정

## ✨ PR 상세 내용
- 다음 정산 생성시 기존 계좌 연결되지 않는 오류 수정
(동일한지 확인하는 비교문 문제)
- 선배 회원가입할 때 salary 2주치 생성
(목요일에 가입하는 경우 정산 자동 생성이 되지 않아 다음 정산이 비어버리는 경우 개선을 위해)
- 다음 정산 자동 생성시 이미 존재하는 경우 정산 생성하지 않고 넘어가도록 수정
(회원가입한 선배의 경우 이미 다음 정산을 가지고 있기 때문에 넘어가도록 작성)

## 🚨 주의 사항
정산 자동 생성의 로직에서 빈틈이 존재하는 것을 수정하기 위해 회원가입할 때 2주치 함께 생성하도록 수정함
이에 따라 발생할 수 있는 문제에 대한 관찰이 필요함

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
