### PR TITLE
RAC-341 fix : 멘토링 완료건 조회시 완료일순 정렬

### DIFF
--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCase.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.postgraduate.domain.mentoring.application.mapper.MentoringMapper.*;
+import static com.postgraduate.domain.mentoring.util.DateUtils.stringToLocalDateTime;
 import static java.time.Duration.between;
 
 @Service
@@ -70,6 +71,12 @@ public class MentoringSeniorInfoUseCase {
         List<Mentoring> mentorings = mentoringGetService.bySeniorDone(senior);
         List<DoneSeniorMentoringInfo> doneSeniorMentoringInfos = mentorings.stream()
                 .map(MentoringMapper::mapToSeniorDoneInfo)
+                .sorted((o1, o2) -> {
+                    if (stringToLocalDateTime(o1.date())
+                            .isAfter(stringToLocalDateTime(o2.date())))
+                        return -1;
+                    return 1;
+                })
                 .toList();
         return new DoneSeniorMentoringResponse(doneSeniorMentoringInfos);
     }

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCase.java
@@ -3,7 +3,10 @@ package com.postgraduate.domain.mentoring.application.usecase;
 import com.postgraduate.domain.mentoring.application.dto.DoneMentoringInfo;
 import com.postgraduate.domain.mentoring.application.dto.ExpectedMentoringInfo;
 import com.postgraduate.domain.mentoring.application.dto.WaitingMentoringInfo;
-import com.postgraduate.domain.mentoring.application.dto.res.*;
+import com.postgraduate.domain.mentoring.application.dto.res.AppliedMentoringDetailResponse;
+import com.postgraduate.domain.mentoring.application.dto.res.DoneMentoringResponse;
+import com.postgraduate.domain.mentoring.application.dto.res.ExpectedMentoringResponse;
+import com.postgraduate.domain.mentoring.application.dto.res.WaitingMentoringResponse;
 import com.postgraduate.domain.mentoring.application.mapper.MentoringMapper;
 import com.postgraduate.domain.mentoring.domain.entity.Mentoring;
 import com.postgraduate.domain.mentoring.domain.service.MentoringGetService;
@@ -15,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static com.postgraduate.domain.mentoring.application.mapper.MentoringMapper.mapToAppliedDetailInfo;
+import static com.postgraduate.domain.mentoring.util.DateUtils.stringToLocalDateTime;
 
 @Service
 @Transactional(readOnly = true)
@@ -47,6 +51,12 @@ public class MentoringUserInfoUseCase {
         List<Mentoring> mentorings = mentoringGetService.byUserDone(user);
         List<DoneMentoringInfo> doneMentoringInfos = mentorings.stream()
                 .map(MentoringMapper::mapToDoneInfo)
+                .sorted((o1, o2) -> {
+                    if (stringToLocalDateTime(o1.date())
+                            .isAfter(stringToLocalDateTime(o2.date())))
+                        return -1;
+                    return 1;
+                })
                 .toList();
         return new DoneMentoringResponse(doneMentoringInfos);
     }

--- a/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseCaseTest.java
@@ -1,5 +1,6 @@
 package com.postgraduate.domain.mentoring.application.usecase;
 
+import com.postgraduate.domain.mentoring.application.dto.DoneSeniorMentoringInfo;
 import com.postgraduate.domain.mentoring.application.dto.res.DoneSeniorMentoringResponse;
 import com.postgraduate.domain.mentoring.application.dto.res.ExpectedSeniorMentoringResponse;
 import com.postgraduate.domain.mentoring.application.dto.res.WaitingSeniorMentoringResponse;
@@ -155,9 +156,9 @@ class MentoringSeniorInfoUseCaseTest {
         Payment payment2 = new Payment(2l, user, senior, 10000, "1", "1", "a", LocalDateTime.now(), LocalDateTime.now(), Status.DONE);
         Payment payment3 = new Payment(3l, user, senior, 10000, "1", "1", "a", LocalDateTime.now(), LocalDateTime.now(), Status.DONE);
 
-        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment1, salary, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
-        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment2, salary, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
-        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment3, salary, "A", "b", "a", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
+        Mentoring mentoring1 = new Mentoring(1L, user, senior, payment1, salary, "A", "b", "2024-03-02-18-18", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
+        Mentoring mentoring2 = new Mentoring(2L, user, senior, payment2, salary, "A", "b", "2024-02-02-18-18", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
+        Mentoring mentoring3 = new Mentoring(3L, user, senior, payment3, salary, "A", "b", "2024-01-02-18-18", 40, WAITING, LocalDateTime.now(), LocalDateTime.now());
         List<Mentoring> mentorings = List.of(mentoring1, mentoring2, mentoring3);
 
         given(seniorGetService.byUser(user))
@@ -166,8 +167,8 @@ class MentoringSeniorInfoUseCaseTest {
                 .willReturn(mentorings);
 
         DoneSeniorMentoringResponse seniorDone = mentoringSeniorInfoUseCase.getSeniorDone(user);
-
-        assertThat(seniorDone.seniorMentoringInfos())
+        List<DoneSeniorMentoringInfo> doneSeniorMentoringInfos = seniorDone.seniorMentoringInfos();
+        assertThat(doneSeniorMentoringInfos)
                 .hasSameSizeAs(mentorings);
     }
 }

--- a/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCaseTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseCaseTest.java
@@ -147,15 +147,15 @@ class MentoringUserInfoUseCaseTest {
     @DisplayName("DONE 반환 테스트")
     void getDone() {
         Mentoring mentoring1 = new Mentoring(1L, user, senior, payment, null
-                , "a", "b", "c"
+                , "a", "b", "2024-02-03-18-12"
                 , 40, DONE
                 , LocalDateTime.now(), LocalDateTime.now());
         Mentoring mentoring2 = new Mentoring(2L, user, senior, payment, null
-                , "a", "b", "c"
+                , "a", "b", "2024-02-03-18-12"
                 , 40, DONE
                 , LocalDateTime.now(), LocalDateTime.now());
         Mentoring mentoring3 = new Mentoring(3L, user, senior, payment, null
-                , "a", "b", "c"
+                , "a", "b", "2024-02-03-18-12"
                 , 40, DONE
                 , LocalDateTime.now(), LocalDateTime.now());
         List<Mentoring> mentorings = List.of(mentoring1, mentoring2, mentoring3);

--- a/src/test/java/com/postgraduate/support/Resource.java
+++ b/src/test/java/com/postgraduate/support/Resource.java
@@ -34,7 +34,7 @@ public class Resource {
     private Payment payment = new Payment(0L, user, senior, 20000, "1", "123", "123", LocalDateTime.now(), LocalDateTime.now(), DONE);
     private Mentoring waitingMentoring = new Mentoring(0L, user, senior, payment, salary, "topic", "question", "date1,date2,date3", 30, WAITING, now(), now());
     private Mentoring expectedMentoring = new Mentoring(0L, user, senior, payment, salary, "topic", "question", "date", 30, EXPECTED, now(), now());
-    private Mentoring doneMentoring = new Mentoring(0L, user, senior, payment, salary, "topic", "question", "date", 30, Status.DONE, now(), now());
+    private Mentoring doneMentoring = new Mentoring(0L, user, senior, payment, salary, "topic", "question", "2024-02-03-18-12", 30, Status.DONE, now(), now());
     private List<Available> availables = List.of(
             new Available(0L, "월", "17:00", "23:00", senior),
             new Available(0L, "금", "10:00", "20:00", senior),


### PR DESCRIPTION
## 🦝 PR 요약
멘토링 완료건 조회시 완료일순 정렬

## ✨ PR 상세 내용
기존에 멘토링 생성일로 조회되는 것 완료건 조회시 완료일 순으로 수정

## 🚨 주의 사항
쿼리 기반이 아닌, 내부에서 sort를 사용하는 것으로 무엇이 나은지 추가적인 고려 필요

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
