### PR TITLE
RAC-347 HotFix : 선배 프로필 최초 작성시 seniorid반환 하도록 수정

### DIFF
--- a/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseCase.java
@@ -61,7 +61,7 @@ public class SeniorManageUseCase {
         seniorUpdateService.updateCertification(senior, certificationRequest.certification());
     }
 
-    public void signUpProfile(User user, SeniorProfileRequest profileRequest) {
+    public SeniorProfileUpdateResponse signUpProfile(User user, SeniorProfileRequest profileRequest) {
         Senior senior = seniorGetService.byUser(user);
         Profile profile = mapToProfile(profileRequest);
         seniorUpdateService.signUpSeniorProfile(senior, profile);
@@ -69,6 +69,7 @@ public class SeniorManageUseCase {
         availableDeleteService.delete(senior);
         List<Available> sortedAvailable = sortAvailable(availableCreateRequests, senior);
         sortedAvailable.forEach(availableSaveService::save);
+        return new SeniorProfileUpdateResponse(senior.getSeniorId());
     }
 
     public void saveAccount(User user, SeniorAccountRequest accountRequest) {

--- a/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
+++ b/src/main/java/com/postgraduate/domain/senior/presentation/SeniorController.java
@@ -45,10 +45,10 @@ public class SeniorController {
 
     @PatchMapping("/profile")
     @Operation(summary = "대학원생 프로필 등록 | 토큰 필요")
-    public ResponseDto<Void> singUpSenior(@AuthenticationPrincipal User user,
+    public ResponseDto<SeniorProfileUpdateResponse> singUpSenior(@AuthenticationPrincipal User user,
                                     @RequestBody @Valid SeniorProfileRequest profileRequest) {
-        seniorManageUseCase.signUpProfile(user, profileRequest);
-        return ResponseDto.create(SENIOR_UPDATE.getCode(), UPDATE_PROFILE.getMessage());
+        SeniorProfileUpdateResponse updateResponse = seniorManageUseCase.signUpProfile(user, profileRequest);
+        return ResponseDto.create(SENIOR_UPDATE.getCode(), UPDATE_PROFILE.getMessage(), updateResponse);
     }
 
     @PostMapping("/account")

--- a/src/test/java/com/postgraduate/domain/senior/presentation/SeniorControllerTest.java
+++ b/src/test/java/com/postgraduate/domain/senior/presentation/SeniorControllerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.ResultMatcher;
 
 import java.util.List;
 
@@ -89,9 +90,10 @@ class SeniorControllerTest extends ControllerTest {
         String request = objectMapper.writeValueAsString(
                 new SeniorProfileRequest("저는요", "대상", "chatLink", "한줄소개", availableCreateRequests)
         );
+        SeniorProfileUpdateResponse response = new SeniorProfileUpdateResponse(senior.getSeniorId());
 
-        willDoNothing().given(seniorManageUseCase)
-                        .signUpProfile(any(), any());
+        given(seniorManageUseCase.signUpProfile(any(), any()))
+                .willReturn(response);
 
         mvc.perform(patch("/senior/profile")
                         .header(HttpHeaders.AUTHORIZATION, BEARER)
@@ -101,7 +103,8 @@ class SeniorControllerTest extends ControllerTest {
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(SENIOR_UPDATE.getCode()))
-                .andExpect(jsonPath("$.message").value(UPDATE_PROFILE.getMessage()));
+                .andExpect(jsonPath("$.message").value(UPDATE_PROFILE.getMessage()))
+                .andExpect(jsonPath("$.data.seniorId").value(response.seniorId()));
     }
 
     @Test


### PR DESCRIPTION
## 🦝 PR 요약
선배 프로필 최초 작성시 seniorid반환 하도록 수정

## ✨ PR 상세 내용
senior/profile 에서도 seniorId반환 추가

## 🚨 주의 사항
주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
