### PR TITLE
RAC-351 HotFix : 알림톡 예외 발생시 기존 비즈니스 로직 영향 없도록 수정

### DIFF
--- a/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioJuniorMessage.java
+++ b/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioJuniorMessage.java
@@ -1,5 +1,6 @@
 package com.postgraduate.global.bizppurio.usecase;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
@@ -27,41 +28,58 @@ public class BizppurioJuniorMessage {
     private String messageUrl;
 
     public void mentoringApply(User user) {
-        CommonRequest commonRequest = mapper.mapToJuniorApplyMessage(user);
-        sendMessage(commonRequest);
+        try {
+            CommonRequest commonRequest = mapper.mapToJuniorApplyMessage(user);
+            sendMessage(commonRequest);
+        } catch (Exception ex) {
+            log.error("알림톡 전송 예외 발생");
+            log.error("{}", ex.getMessage());
+        }
     }
 
     public void mentoringAccept(User user, Senior senior, String time) {
-        String chatLink = senior.getProfile().getChatLink();
-        CommonRequest commonRequest = mapper.mapToJuniorAcceptMessage(user, chatLink, time);
-        sendMessage(commonRequest);
+        try {
+            String chatLink = senior.getProfile().getChatLink();
+            CommonRequest commonRequest = mapper.mapToJuniorAcceptMessage(user, chatLink, time);
+            sendMessage(commonRequest);
+        } catch (Exception ex) {
+            log.error("알림톡 전송 예외 발생");
+            log.error("{}", ex.getMessage());
+        }
     }
 
     public void mentoringRefuse(User user) {
-        CommonRequest commonRequest = mapper.mapToJuniorRefuseMessage(user);
-        sendMessage(commonRequest);
+        try {
+            CommonRequest commonRequest = mapper.mapToJuniorRefuseMessage(user);
+            sendMessage(commonRequest);
+        } catch (Exception ex) {
+            log.error("알림톡 전송 예외 발생");
+            log.error("{}", ex.getMessage());
+        }
+
     }
 
     public void mentoringFinish(User user) {
-        CommonRequest commonRequest = mapper.mapToJuniorFinish(user);
-        sendMessage(commonRequest);
-    }
-
-    private void sendMessage(CommonRequest commonRequest) {
         try {
-            String accessToken = bizppurioAuth.getAuth();
-            String request = objectMapper.writeValueAsString(commonRequest);
-            webClient.post()
-                    .uri(messageUrl)
-                    .headers(h -> h.setContentType(APPLICATION_JSON))
-                    .headers(h -> h.setBearerAuth(accessToken))
-                    .bodyValue(request)
-                    .retrieve()
-                    .bodyToMono(MessageResponse.class)
-                    .subscribe(this::check);
+            CommonRequest commonRequest = mapper.mapToJuniorFinish(user);
+            sendMessage(commonRequest);
         } catch (Exception ex) {
             log.error("알림톡 전송 예외 발생");
+            log.error("{}", ex.getMessage());
         }
+    }
+
+    private void sendMessage(CommonRequest commonRequest) throws JsonProcessingException {
+        String accessToken = bizppurioAuth.getAuth();
+        String request = objectMapper.writeValueAsString(commonRequest);
+        webClient.post()
+                .uri(messageUrl)
+                .headers(h -> h.setContentType(APPLICATION_JSON))
+                .headers(h -> h.setBearerAuth(accessToken))
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(MessageResponse.class)
+                .subscribe(this::check);
     }
 
     private void check(MessageResponse response) {

--- a/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioJuniorMessage.java
+++ b/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioJuniorMessage.java
@@ -1,75 +1,35 @@
 package com.postgraduate.global.bizppurio.usecase;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
-import com.postgraduate.global.bizppurio.dto.req.CommonRequest;
-import com.postgraduate.global.bizppurio.dto.res.MessageResponse;
 import com.postgraduate.global.bizppurio.mapper.BizppurioMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
-
-import java.util.function.Supplier;
-
-import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 @RequiredArgsConstructor
 @Component
 @Slf4j
 public class BizppurioJuniorMessage {
-    private final WebClient webClient;
-    private final BizppurioAuth bizppurioAuth;
-    private final ObjectMapper objectMapper;
     private final BizppurioMapper mapper;
-
-    @Value("${bizppurio.message}")
-    private String messageUrl;
+    private final BizppurioSend bizppurioSend;
 
     public void mentoringApply(User user) {
-        sendMessageWithExceptionHandling(() -> mapper.mapToJuniorApplyMessage(user));
+        bizppurioSend.sendMessageWithExceptionHandling(() -> mapper.mapToJuniorApplyMessage(user));
     }
 
     public void mentoringAccept(User user, Senior senior, String time) {
-        sendMessageWithExceptionHandling(() -> {
+        bizppurioSend.sendMessageWithExceptionHandling(() -> {
             String chatLink = senior.getProfile().getChatLink();
             return mapper.mapToJuniorAcceptMessage(user, chatLink, time);
         });
     }
 
     public void mentoringRefuse(User user) {
-        sendMessageWithExceptionHandling(() -> mapper.mapToJuniorRefuseMessage(user));
+        bizppurioSend.sendMessageWithExceptionHandling(() -> mapper.mapToJuniorRefuseMessage(user));
     }
 
     public void mentoringFinish(User user) {
-        sendMessageWithExceptionHandling(() -> mapper.mapToJuniorFinish(user));
-    }
-
-    private void sendMessageWithExceptionHandling(Supplier<CommonRequest> messageSupplier) {
-        try {
-            CommonRequest commonRequest = messageSupplier.get();
-            String accessToken = bizppurioAuth.getAuth();
-            String request = objectMapper.writeValueAsString(commonRequest);
-            webClient.post()
-                    .uri(messageUrl)
-                    .headers(h -> h.setContentType(APPLICATION_JSON))
-                    .headers(h -> h.setBearerAuth(accessToken))
-                    .bodyValue(request)
-                    .retrieve()
-                    .bodyToMono(MessageResponse.class)
-                    .subscribe(this::check);
-        } catch (Exception ex) {
-            log.error("알림톡 전송 예외 발생: {}", ex.getMessage());
-        }
-    }
-
-    private void check(MessageResponse response) {
-        if (response.code() != 1000) {
-            log.error("전송실패 errorCode : {} errorMessage : {}", response.code(), response.description());
-            return;
-        }
-        log.info("알림톡 전송에 성공하였습니다.");
+        bizppurioSend.sendMessageWithExceptionHandling(() -> mapper.mapToJuniorFinish(user));
     }
 }

--- a/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioSend.java
+++ b/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioSend.java
@@ -1,0 +1,52 @@
+package com.postgraduate.global.bizppurio.usecase;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.postgraduate.global.bizppurio.dto.req.CommonRequest;
+import com.postgraduate.global.bizppurio.dto.res.MessageResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.function.Supplier;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class BizppurioSend {
+    private final BizppurioAuth bizppurioAuth;
+    private final ObjectMapper objectMapper;
+    private final WebClient webClient;
+
+    @Value("${bizppurio.message}")
+    private String messageUrl;
+
+    protected void sendMessageWithExceptionHandling(Supplier<CommonRequest> messageSupplier) {
+        try {
+            CommonRequest commonRequest = messageSupplier.get();
+            String accessToken = bizppurioAuth.getAuth();
+            String request = objectMapper.writeValueAsString(commonRequest);
+            webClient.post()
+                    .uri(messageUrl)
+                    .headers(h -> h.setContentType(APPLICATION_JSON))
+                    .headers(h -> h.setBearerAuth(accessToken))
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(MessageResponse.class)
+                    .subscribe(this::check);
+        } catch (Exception ex) {
+            log.error("알림톡 전송 예외 발생: {}", ex.getMessage());
+        }
+    }
+
+    private void check(MessageResponse response) {
+        if (response.code() != 1000) {
+            log.error("전송실패 errorCode : {} errorMessage : {}", response.code(), response.description());
+            return;
+        }
+        log.info("알림톡 전송에 성공하였습니다.");
+    }
+}

--- a/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioSeniorMessage.java
+++ b/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioSeniorMessage.java
@@ -1,6 +1,5 @@
 package com.postgraduate.global.bizppurio.usecase;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
@@ -14,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import java.util.function.Supplier;
 
 @RequiredArgsConstructor
 @Component
@@ -28,78 +28,49 @@ public class BizppurioSeniorMessage {
     private String messageUrl;
 
     public void signUp(User user) {
-        try {
-            CommonRequest commonRequest = mapper.mapToSeniorSignUpMessage(user);
-            sendMessage(commonRequest);
-        } catch (Exception ex) {
-            log.error("알림톡 전송 예외 발생");
-            log.error("{}", ex.getMessage());
-        }
+        sendMessageWithExceptionHandling(() -> mapper.mapToSeniorSignUpMessage(user));
     }
 
     public void mentoringApply(User user) {
-        try {
-            CommonRequest commonRequest = mapper.mapToSeniorApplyMessage(user);
-            sendMessage(commonRequest);
-        } catch (Exception ex) {
-            log.error("알림톡 전송 예외 발생");
-            log.error("{}", ex.getMessage());
-        }
+        sendMessageWithExceptionHandling(() -> mapper.mapToSeniorApplyMessage(user));
     }
 
     public void mentoringAccept(Senior senior, String time) {
-        try {
+        sendMessageWithExceptionHandling(() -> {
             User user = senior.getUser();
             String chatLink = senior.getProfile().getChatLink();
-            CommonRequest commonRequest = mapper.mapToSeniorAcceptMessage(user, chatLink, time);
-            sendMessage(commonRequest);
-        } catch (Exception ex) {
-            log.error("알림톡 전송 예외 발생");
-            log.error("{}", ex.getMessage());
-        }
+            return mapper.mapToSeniorAcceptMessage(user, chatLink, time);
+        });
     }
 
     public void certificationApprove(User user) {
-        try {
-            CommonRequest commonRequest = mapper.mapToCertificationApprove(user);
-            sendMessage(commonRequest);
-        } catch (Exception ex) {
-            log.error("알림톡 전송 예외 발생");
-            log.error("{}", ex.getMessage());
-        }
+        sendMessageWithExceptionHandling(() -> mapper.mapToCertificationApprove(user));
     }
 
     public void certificationDenied(User user) {
-        try {
-            CommonRequest commonRequest = mapper.mapToCertificationDenied(user);
-            sendMessage(commonRequest);
-        } catch (Exception ex) {
-            log.error("알림톡 전송 예외 발생");
-            log.error("{}", ex.getMessage());
-        }
+        sendMessageWithExceptionHandling(() -> mapper.mapToCertificationDenied(user));
     }
 
     public void mentoringFinish(User user) {
-        try {
-            CommonRequest commonRequest = mapper.mapToSeniorFinish(user);
-            sendMessage(commonRequest);
-        } catch (Exception ex) {
-            log.error("알림톡 전송 예외 발생");
-            log.error("{}", ex.getMessage());
-        }
+        sendMessageWithExceptionHandling(() -> mapper.mapToSeniorFinish(user));
     }
 
-    private void sendMessage(CommonRequest commonRequest) throws JsonProcessingException {
-        String accessToken = bizppurioAuth.getAuth();
-        String request = objectMapper.writeValueAsString(commonRequest);
-        webClient.post()
-                .uri(messageUrl)
-                .headers(h -> h.setContentType(APPLICATION_JSON))
-                .headers(h -> h.setBearerAuth(accessToken))
-                .bodyValue(request)
-                .retrieve()
-                .bodyToMono(MessageResponse.class)
-                .subscribe(this::check);
+    private void sendMessageWithExceptionHandling(Supplier<CommonRequest> messageSupplier) {
+        try {
+            CommonRequest commonRequest = messageSupplier.get();
+            String accessToken = bizppurioAuth.getAuth();
+            String request = objectMapper.writeValueAsString(commonRequest);
+            webClient.post()
+                    .uri(messageUrl)
+                    .headers(h -> h.setContentType(APPLICATION_JSON))
+                    .headers(h -> h.setBearerAuth(accessToken))
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(MessageResponse.class)
+                    .subscribe(this::check);
+        } catch (Exception ex) {
+            log.error("알림톡 전송 예외 발생: {}", ex.getMessage());
+        }
     }
 
     private void check(MessageResponse response) {

--- a/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioSeniorMessage.java
+++ b/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioSeniorMessage.java
@@ -11,11 +11,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import static com.postgraduate.global.bizppurio.mapper.BizppurioMapper.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 @RequiredArgsConstructor
@@ -31,53 +28,78 @@ public class BizppurioSeniorMessage {
     private String messageUrl;
 
     public void signUp(User user) {
-        CommonRequest commonRequest = mapper.mapToSeniorSignUpMessage(user);
-        sendMessage(commonRequest);
-    }
-
-    public void mentoringApply(User user) {
-        CommonRequest commonRequest = mapper.mapToSeniorApplyMessage(user);
-        sendMessage(commonRequest);
-    }
-
-    public void mentoringAccept(Senior senior, String time) {
-        User user = senior.getUser();
-        String chatLink = senior.getProfile().getChatLink();
-        CommonRequest commonRequest = mapper.mapToSeniorAcceptMessage(user, chatLink, time);
-        sendMessage(commonRequest);
-    }
-
-    public void certificationApprove(User user) {
-        CommonRequest commonRequest = mapper.mapToCertificationApprove(user);
-        sendMessage(commonRequest);
-    }
-
-    public void certificationDenied(User user) {
-        CommonRequest commonRequest = mapper.mapToCertificationDenied(user);
-        sendMessage(commonRequest);
-    }
-
-    public void mentoringFinish(User user) {
-        CommonRequest commonRequest = mapper.mapToSeniorFinish(user);
-        sendMessage(commonRequest);
-    }
-
-    private void sendMessage(CommonRequest commonRequest) {
         try {
-            String accessToken = bizppurioAuth.getAuth();
-            String request = objectMapper.writeValueAsString(commonRequest);
-            webClient.post()
-                    .uri(messageUrl)
-                    .headers(h -> h.setContentType(APPLICATION_JSON))
-                    .headers(h -> h.setBearerAuth(accessToken))
-                    .bodyValue(request)
-                    .retrieve()
-                    .bodyToMono(MessageResponse.class)
-                    .subscribe(this::check);
+            CommonRequest commonRequest = mapper.mapToSeniorSignUpMessage(user);
+            sendMessage(commonRequest);
         } catch (Exception ex) {
             log.error("알림톡 전송 예외 발생");
             log.error("{}", ex.getMessage());
         }
+    }
+
+    public void mentoringApply(User user) {
+        try {
+            CommonRequest commonRequest = mapper.mapToSeniorApplyMessage(user);
+            sendMessage(commonRequest);
+        } catch (Exception ex) {
+            log.error("알림톡 전송 예외 발생");
+            log.error("{}", ex.getMessage());
+        }
+    }
+
+    public void mentoringAccept(Senior senior, String time) {
+        try {
+            User user = senior.getUser();
+            String chatLink = senior.getProfile().getChatLink();
+            CommonRequest commonRequest = mapper.mapToSeniorAcceptMessage(user, chatLink, time);
+            sendMessage(commonRequest);
+        } catch (Exception ex) {
+            log.error("알림톡 전송 예외 발생");
+            log.error("{}", ex.getMessage());
+        }
+    }
+
+    public void certificationApprove(User user) {
+        try {
+            CommonRequest commonRequest = mapper.mapToCertificationApprove(user);
+            sendMessage(commonRequest);
+        } catch (Exception ex) {
+            log.error("알림톡 전송 예외 발생");
+            log.error("{}", ex.getMessage());
+        }
+    }
+
+    public void certificationDenied(User user) {
+        try {
+            CommonRequest commonRequest = mapper.mapToCertificationDenied(user);
+            sendMessage(commonRequest);
+        } catch (Exception ex) {
+            log.error("알림톡 전송 예외 발생");
+            log.error("{}", ex.getMessage());
+        }
+    }
+
+    public void mentoringFinish(User user) {
+        try {
+            CommonRequest commonRequest = mapper.mapToSeniorFinish(user);
+            sendMessage(commonRequest);
+        } catch (Exception ex) {
+            log.error("알림톡 전송 예외 발생");
+            log.error("{}", ex.getMessage());
+        }
+    }
+
+    private void sendMessage(CommonRequest commonRequest) throws JsonProcessingException {
+        String accessToken = bizppurioAuth.getAuth();
+        String request = objectMapper.writeValueAsString(commonRequest);
+        webClient.post()
+                .uri(messageUrl)
+                .headers(h -> h.setContentType(APPLICATION_JSON))
+                .headers(h -> h.setBearerAuth(accessToken))
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(MessageResponse.class)
+                .subscribe(this::check);
     }
 
     private void check(MessageResponse response) {

--- a/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioSeniorMessage.java
+++ b/src/main/java/com/postgraduate/global/bizppurio/usecase/BizppurioSeniorMessage.java
@@ -1,42 +1,29 @@
 package com.postgraduate.global.bizppurio.usecase;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
-import com.postgraduate.global.bizppurio.dto.req.CommonRequest;
-import com.postgraduate.global.bizppurio.dto.res.MessageResponse;
 import com.postgraduate.global.bizppurio.mapper.BizppurioMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
-
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import java.util.function.Supplier;
 
 @RequiredArgsConstructor
 @Component
 @Slf4j
 public class BizppurioSeniorMessage {
-    private final WebClient webClient;
     private final BizppurioMapper mapper;
-    private final BizppurioAuth bizppurioAuth;
-    private final ObjectMapper objectMapper;
-
-    @Value("${bizppurio.message}")
-    private String messageUrl;
+    private final BizppurioSend bizppurioSend;
 
     public void signUp(User user) {
-        sendMessageWithExceptionHandling(() -> mapper.mapToSeniorSignUpMessage(user));
+        bizppurioSend.sendMessageWithExceptionHandling(() -> mapper.mapToSeniorSignUpMessage(user));
     }
 
     public void mentoringApply(User user) {
-        sendMessageWithExceptionHandling(() -> mapper.mapToSeniorApplyMessage(user));
+        bizppurioSend.sendMessageWithExceptionHandling(() -> mapper.mapToSeniorApplyMessage(user));
     }
 
     public void mentoringAccept(Senior senior, String time) {
-        sendMessageWithExceptionHandling(() -> {
+        bizppurioSend.sendMessageWithExceptionHandling(() -> {
             User user = senior.getUser();
             String chatLink = senior.getProfile().getChatLink();
             return mapper.mapToSeniorAcceptMessage(user, chatLink, time);
@@ -44,40 +31,14 @@ public class BizppurioSeniorMessage {
     }
 
     public void certificationApprove(User user) {
-        sendMessageWithExceptionHandling(() -> mapper.mapToCertificationApprove(user));
+        bizppurioSend.sendMessageWithExceptionHandling(() -> mapper.mapToCertificationApprove(user));
     }
 
     public void certificationDenied(User user) {
-        sendMessageWithExceptionHandling(() -> mapper.mapToCertificationDenied(user));
+        bizppurioSend.sendMessageWithExceptionHandling(() -> mapper.mapToCertificationDenied(user));
     }
 
     public void mentoringFinish(User user) {
-        sendMessageWithExceptionHandling(() -> mapper.mapToSeniorFinish(user));
-    }
-
-    private void sendMessageWithExceptionHandling(Supplier<CommonRequest> messageSupplier) {
-        try {
-            CommonRequest commonRequest = messageSupplier.get();
-            String accessToken = bizppurioAuth.getAuth();
-            String request = objectMapper.writeValueAsString(commonRequest);
-            webClient.post()
-                    .uri(messageUrl)
-                    .headers(h -> h.setContentType(APPLICATION_JSON))
-                    .headers(h -> h.setBearerAuth(accessToken))
-                    .bodyValue(request)
-                    .retrieve()
-                    .bodyToMono(MessageResponse.class)
-                    .subscribe(this::check);
-        } catch (Exception ex) {
-            log.error("알림톡 전송 예외 발생: {}", ex.getMessage());
-        }
-    }
-
-    private void check(MessageResponse response) {
-        if (response.code() != 1000) {
-            log.error("전송실패 errorCode : {} errorMessage : {}", response.code(), response.description());
-            return;
-        }
-        log.info("알림톡 전송에 성공하였습니다.");
+        bizppurioSend.sendMessageWithExceptionHandling(() -> mapper.mapToSeniorFinish(user));
     }
 }


### PR DESCRIPTION
## 🦝 PR 요약
알림톡 예외 발생시 기존 비즈니스 로직 영향 없도록 수정

## ✨ PR 상세 내용
알림톡 템플릿별 모든 메소드에 try/catch를 추가하여 로그 작성 후 무시하도록 수정

## 🚨 주의 사항
더 좋은 방법이 없는지 고민 필요

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
