### PR TITLE
RAC-364 HotFix : 계좌 업데이트시 정산 동기화 오류 수정

### DIFF
--- a/src/main/java/com/postgraduate/domain/salary/domain/repository/SalaryDslRepositoryImpl.java
+++ b/src/main/java/com/postgraduate/domain/salary/domain/repository/SalaryDslRepositoryImpl.java
@@ -127,13 +127,14 @@ public class SalaryDslRepositoryImpl implements SalaryDslRepository {
 
     @Override
     public List<Salary> findAllBySalaryNoneAccount(LocalDate salaryDate, Senior searchSenior) {
-        Salary nowSalary = queryFactory.selectFrom(salary)
+        List<Salary> nowSalaries = queryFactory.selectFrom(salary)
                 .where(
                         salary.senior.eq(searchSenior),
                         salary.salaryDate.eq(salaryDate)
+                                .or(salary.salaryDate.goe(salaryDate))
                 )
-                .fetchOne();
-        if (nowSalary.getAccount() == null) {
+                .fetch();
+        if (nowSalaries.get(0).getAccount() == null) {
             return queryFactory.selectFrom(salary)
                     .distinct()
                     .where(
@@ -144,7 +145,7 @@ public class SalaryDslRepositoryImpl implements SalaryDslRepository {
                     .fetchJoin()
                     .fetch();
         }
-        return List.of(nowSalary);
+        return nowSalaries;
     }
 }
 


### PR DESCRIPTION
## 🦝 PR 요약
계좌 업데이트시 정산 동기화 오류 수정

## ✨ PR 상세 내용
- Before : 기존 계좌 존재하는 경우, 이번 정산만 조회하여 동기화 작업을 수행함
- After : 기존 계좌 존재하는 경우, 이번 정산일보다 정산일이 크거나 같은 정산을 모두 조회하여 모두 동기화 작업 수행

## 🚨 주의 사항
긴급 수정으로 관찰 필요 및 스프링 배치로 리팩토링시 고려 필요

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
