### PR TITLE
RAC-367 feat : 후배 회원가입시 매칭 동의여부에 따라 알림톡 전송 기능 추가

### DIFF
--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseCase.java
@@ -15,6 +15,7 @@ import com.postgraduate.domain.user.domain.service.UserUpdateService;
 import com.postgraduate.domain.wish.application.mapper.WishMapper;
 import com.postgraduate.domain.wish.domain.entity.Wish;
 import com.postgraduate.domain.wish.domain.service.WishSaveService;
+import com.postgraduate.global.bizppurio.application.usecase.BizppurioJuniorMessage;
 import com.postgraduate.global.bizppurio.application.usecase.BizppurioSeniorMessage;
 import com.postgraduate.global.slack.SlackSignUpMessage;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +44,7 @@ public class SignUpUseCase {
     private final UserUtils userUtils;
     private final SeniorUtils seniorUtils;
     private final BizppurioSeniorMessage bizppurioSeniorMessage;
+    private final BizppurioJuniorMessage bizppurioJuniorMessage;
 
     public User userSignUp(SignUpRequest request) {
         userUtils.checkPhoneNumber(request.phoneNumber());
@@ -50,6 +52,8 @@ public class SignUpUseCase {
         Wish wish = WishMapper.mapToWish(user, request);
         wishSaveService.save(wish);
         userSaveService.save(user);
+        if (request.matchingReceive())
+            bizppurioJuniorMessage.matchingWaiting(user);
         slackSignUpMessage.sendJuniorSignUp(user, wish);
         return user;
     }
@@ -72,6 +76,8 @@ public class SignUpUseCase {
     public void changeUser(User user, UserChangeRequest changeRequest) {
         Wish wish = WishMapper.mapToWish(user, changeRequest);
         wishSaveService.save(wish);
+        if (changeRequest.matchingReceive())
+            bizppurioJuniorMessage.matchingWaiting(user);
         slackSignUpMessage.sendJuniorSignUp(user, wish);
     }
 

--- a/src/main/java/com/postgraduate/global/bizppurio/application/mapper/BizppurioMapper.java
+++ b/src/main/java/com/postgraduate/global/bizppurio/application/mapper/BizppurioMapper.java
@@ -1,11 +1,10 @@
 package com.postgraduate.global.bizppurio.application.mapper;
 
-import com.postgraduate.global.bizppurio.application.dto.req.JuniorMatchingFailRequest;
-import com.postgraduate.global.bizppurio.application.dto.req.JuniorMatchingSuccessRequest;
-import com.postgraduate.global.bizppurio.application.dto.req.JuniorMatchingWaitingRequest;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.global.bizppurio.application.dto.req.CommonRequest;
 import com.postgraduate.global.bizppurio.application.dto.req.ContentRequest;
+import com.postgraduate.global.bizppurio.application.dto.req.JuniorMatchingFailRequest;
+import com.postgraduate.global.bizppurio.application.dto.req.JuniorMatchingSuccessRequest;
 import com.postgraduate.global.bizppurio.application.dto.req.content.*;
 import com.postgraduate.global.bizppurio.application.dto.req.content.button.WebLinkButton;
 import org.springframework.beans.factory.annotation.Value;
@@ -239,19 +238,19 @@ public class BizppurioMapper {
         return createCommonRequest(messageBody, request.phoneNumber());
     }
 
-    public CommonRequest mapToJuniorMatchingWaiting(JuniorMatchingWaitingRequest request) {
+    public CommonRequest mapToJuniorMatchingWaiting(User user) {
         String message = (
-                "안녕하세요, " + request.name() + "님.\n" +
+                "안녕하세요, " + user.getNickName() + "님.\n" +
                         "\n" +
                         "김선배와 함께 해주셔서 감사드립니다.\n" +
                         "\n" +
-                        request.name() + "님이 신청한 선배를 저희 김선배에서 찾고 있어요 !\n" +
+                        user.getNickName() + "님이 신청한 선배를 저희 김선배에서 찾고 있어요 !\n" +
                         "\n" +
                         "신청해주신 선배를 찾는데에는 3~7일 정도 소요되어요 \uD83D\uDE0A"
-                );
+        );
 
         JuniorMatchingWaitingMessage messageBody = new JuniorMatchingWaitingMessage(message, senderKey, juniorMatchingWaiting);
-        return createCommonRequest(messageBody, request.phoneNumber());
+        return createCommonRequest(messageBody, user.getPhoneNumber());
     }
 
     private CommonRequest createCommonRequest(Message messageBody, String phoneNumber) {

--- a/src/main/java/com/postgraduate/global/bizppurio/application/usecase/BizppurioJuniorMessage.java
+++ b/src/main/java/com/postgraduate/global/bizppurio/application/usecase/BizppurioJuniorMessage.java
@@ -4,7 +4,6 @@ import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.global.bizppurio.application.dto.req.JuniorMatchingFailRequest;
 import com.postgraduate.global.bizppurio.application.dto.req.JuniorMatchingSuccessRequest;
-import com.postgraduate.global.bizppurio.application.dto.req.JuniorMatchingWaitingRequest;
 import com.postgraduate.global.bizppurio.application.mapper.BizppurioMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,8 +35,8 @@ public class BizppurioJuniorMessage {
         bizppurioSend.sendMessageWithExceptionHandling(() -> mapper.mapToJuniorFinish(user));
     }
 
-    public void matchingWaiting(JuniorMatchingWaitingRequest request) {
-        bizppurioSend.sendMessageWithExceptionHandling(() -> mapper.mapToJuniorMatchingWaiting(request));
+    public void matchingWaiting(User user) {
+        bizppurioSend.sendMessageWithExceptionHandling(() -> mapper.mapToJuniorMatchingWaiting(user));
     }
 
     public void matchingFail(JuniorMatchingFailRequest request) {

--- a/src/main/java/com/postgraduate/global/bizppurio/presantation/BizppurioController.java
+++ b/src/main/java/com/postgraduate/global/bizppurio/presantation/BizppurioController.java
@@ -2,9 +2,9 @@ package com.postgraduate.global.bizppurio.presantation;
 
 import com.postgraduate.global.bizppurio.application.dto.req.JuniorMatchingFailRequest;
 import com.postgraduate.global.bizppurio.application.dto.req.JuniorMatchingSuccessRequest;
-import com.postgraduate.global.bizppurio.application.dto.req.JuniorMatchingWaitingRequest;
 import com.postgraduate.global.bizppurio.application.usecase.BizppurioJuniorMessage;
 import com.postgraduate.global.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,19 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class BizppurioController {
     private final BizppurioJuniorMessage bizppurioJuniorMessage;
 
-    @PostMapping("/matching/waiting")
-    public ResponseDto<Void> matchingWaiting(@RequestBody JuniorMatchingWaitingRequest request) {
-        bizppurioJuniorMessage.matchingWaiting(request);
-        return ResponseDto.create("200", request.phoneNumber() + " 번호로 " + request.name() + " 님께 알림톡 전송 완료");
-    }
-
     @PostMapping("/matching/fail")
+    @Operation(summary = "매칭 실패시 전송")
     public ResponseDto<Void> matchingFail(@RequestBody JuniorMatchingFailRequest request) {
         bizppurioJuniorMessage.matchingFail(request);
         return ResponseDto.create("200", request.phoneNumber() + " 번호로 " + request.name() + " 님께 알림톡 전송 완료");
     }
 
     @PostMapping("/matching/success")
+    @Operation(summary = "매칭 성공시 전송")
     public ResponseDto<Void> matchingSuccess(@RequestBody JuniorMatchingSuccessRequest request) {
         bizppurioJuniorMessage.matchingSuccess(request);
         return ResponseDto.create("200", request.phoneNumber() + " 번호로 " + request.name() + " 님께 알림톡 전송 완료");

--- a/src/test/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseTypeTest.java
+++ b/src/test/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseTypeTest.java
@@ -19,6 +19,7 @@ import com.postgraduate.domain.user.exception.PhoneNumberException;
 import com.postgraduate.domain.wish.domain.entity.Wish;
 import com.postgraduate.domain.wish.domain.entity.constant.Status;
 import com.postgraduate.domain.wish.domain.service.WishSaveService;
+import com.postgraduate.global.bizppurio.application.usecase.BizppurioJuniorMessage;
 import com.postgraduate.global.bizppurio.application.usecase.BizppurioSeniorMessage;
 import com.postgraduate.global.slack.SlackSignUpMessage;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,6 +56,8 @@ class SignUpUseTypeTest {
     private WishSaveService wishSaveService;
     @Mock
     private BizppurioSeniorMessage bizppurioSeniorMessage;
+    @Mock
+    private BizppurioJuniorMessage bizppurioJuniorMessage;
     @Mock
     private SeniorSaveService seniorSaveService;
     @Mock


### PR DESCRIPTION
## 🦝 PR 요약
후배 회원가입시 매칭 동의여부에 따라 알림톡 전송 기능 추가

## ✨ PR 상세 내용
- 후배 회원가입시 매칭 동의여부에 따라 알림톡 전송
- 기존 알림톡 수동 전송에서 매칭 대기 알림톡 전송 삭제

## 🚨 주의 사항
주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
