### PR TITLE
RAC-400 feat : 기존 페이징 처리 최적화

### DIFF
--- a/src/main/java/com/postgraduate/domain/senior/domain/entity/Senior.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/entity/Senior.java
@@ -16,6 +16,14 @@ import java.time.LocalDateTime;
 import static com.postgraduate.domain.senior.domain.entity.constant.Status.WAITING;
 
 @Entity
+@Table(indexes = {
+        @Index(name = "senior_total_info_index", columnList = "totalInfo"),
+        @Index(name = "senior_hit_index", columnList = "hit"),
+        @Index(name = "senior_field_index", columnList = "field"),
+        @Index(name = "senior_etc_field_index", columnList = "etcField"),
+        @Index(name = "senior_postgradu_index", columnList = "postgradu"),
+        @Index(name = "senior_etc_postgradu_index", columnList = "etcPostgradu")
+})
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepository.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepository.java
@@ -1,6 +1,5 @@
 package com.postgraduate.domain.senior.domain.repository;
 
-import com.postgraduate.domain.salary.application.dto.SeniorAndAccount;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
 import org.springframework.data.domain.Page;
@@ -10,10 +9,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface SeniorDslRepository {
-    Page<Senior> findAllBySearchSeniorWithAdmin(String search, Pageable pageable);
     Optional<Senior> findBySeniorId(Long seniorId);
     Optional<Senior> findByUserWithAll(User user);
-    List<SeniorAndAccount> findAllSeniorAndAccount();
     List<Senior> findAllSenior();
     Page<Senior> findAllByFieldSenior(String field, String postgradu, Pageable pageable);
     Page<Senior> findAllBySearchSenior(String search, String sort, Pageable pageable);

--- a/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepositoryImpl.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.postgraduate.domain.account.domain.entity.Account;
 import com.postgraduate.domain.salary.application.dto.SeniorAndAccount;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -13,8 +14,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-import org.springframework.util.StringUtils;
+import org.springframework.util.CollectionUtils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -38,20 +40,35 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
 
     @Override
     public Page<Senior> findAllBySearchSenior(String search, String sort, Pageable pageable) {
-        List<Senior> seniors = queryFactory.selectFrom(senior)
+        List<Tuple> results = queryFactory.select(senior.seniorId, senior.user.nickName, senior.hit)
+                .from(senior)
                 .distinct()
                 .leftJoin(senior.user, user)
-                .fetchJoin()
                 .where(
                         senior.info.totalInfo.like("%" + search + "%")
                                 .or(senior.user.nickName.like("%" + search + "%")),
                         senior.user.isDelete.eq(FALSE)
                 )
                 .orderBy(orderSpecifier(sort))
-                .orderBy(senior.user.nickName.asc()).
-                offset(pageable.getOffset())
+                .orderBy(senior.user.nickName.asc())
+                .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
+
+        if (CollectionUtils.isEmpty(results)) {
+            return new PageImpl<>(new ArrayList<>(), pageable, 0);
+        }
+
+        List<Senior> seniors = queryFactory.selectFrom(senior)
+                .where(senior.seniorId.in(results.stream()
+                        .map(tuple -> tuple.get(senior.seniorId))
+                        .toList()))
+                .leftJoin(senior.user, user)
+                .fetchJoin()
+                .orderBy(orderSpecifier(sort))
+                .orderBy(senior.user.nickName.asc())
+                .fetch();
+
 
         Long total = queryFactory.select(senior.count())
                 .from(senior)
@@ -63,7 +80,6 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
                         senior.user.isDelete.eq(FALSE)
                 )
                 .fetchOne();
-
 
         return new PageImpl<>(seniors, pageable, total);
     }
@@ -78,10 +94,10 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
 
     @Override
     public Page<Senior> findAllByFieldSenior(String field, String postgradu, Pageable pageable) {
-        List<Senior> seniors = queryFactory.selectFrom(senior)
+        List<Tuple> results = queryFactory.select(senior.seniorId, senior.user.nickName, senior.hit)
+                .from(senior)
                 .distinct()
                 .leftJoin(senior.user, user)
-                .fetchJoin()
                 .where(
                         fieldSpecifier(field),
                         postgraduSpecifier(postgradu),
@@ -91,6 +107,20 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
                 .orderBy(senior.user.nickName.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
+                .fetch();
+
+        if (CollectionUtils.isEmpty(results)) {
+            return new PageImpl<>(new ArrayList<>(), pageable, 0);
+        }
+
+        List<Senior> seniors = queryFactory.selectFrom(senior)
+                .where(senior.seniorId.in(results.stream()
+                        .map(tuple -> tuple.get(senior.seniorId))
+                        .toList()))
+                .leftJoin(senior.user, user)
+                .fetchJoin()
+                .orderBy(senior.hit.desc())
+                .orderBy(senior.user.nickName.asc())
                 .fetch();
 
         Long total = queryFactory.select(senior.count())
@@ -143,43 +173,6 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
     }
 
     @Override
-    public Page<Senior> findAllBySearchSeniorWithAdmin(String search, Pageable pageable) {
-        List<Senior> seniors = queryFactory.selectFrom(senior)
-                .where(
-                        searchLike(search),
-                        senior.user.isDelete.eq(FALSE)
-                )
-                .distinct()
-                .innerJoin(senior.user, user)
-                .fetchJoin()
-                .orderBy(senior.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
-
-        Long total = queryFactory.select(senior.count())
-                .from(senior)
-                .where(
-                        searchLike(search),
-                        senior.user.isDelete.eq(FALSE)
-                )
-                .distinct()
-                .innerJoin(senior.user, user)
-                .fetchOne();
-
-        return new PageImpl<>(seniors, pageable, total);
-    }
-
-    private BooleanExpression searchLike(String search) {
-        if (StringUtils.hasText(search)) {
-            return senior.user.phoneNumber.contains(search)
-                    .or(senior.user.nickName.contains(search))
-                    .and(senior.profile.isNotNull());
-        }
-        return null;
-    }
-
-    @Override
     public Optional<Senior> findByUserWithAll(User seniorUser) {
         return ofNullable(queryFactory.selectFrom(senior)
                 .distinct()
@@ -206,7 +199,7 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
                 .map(senior -> {
                     Account account = accounts.stream()
                             .filter(a -> a.getSenior().getSeniorId()
-                                            .equals(senior.getSeniorId())
+                                    .equals(senior.getSeniorId())
                             )
                             .findFirst()
                             .orElse(null);

--- a/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepositoryImpl.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepositoryImpl.java
@@ -1,7 +1,5 @@
 package com.postgraduate.domain.senior.domain.repository;
 
-import com.postgraduate.domain.account.domain.entity.Account;
-import com.postgraduate.domain.salary.application.dto.SeniorAndAccount;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.querydsl.core.Tuple;
@@ -21,7 +19,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static com.postgraduate.domain.account.domain.entity.QAccount.account;
 import static com.postgraduate.domain.senior.domain.entity.QSenior.senior;
 import static com.postgraduate.domain.user.domain.entity.QUser.user;
 import static com.querydsl.core.types.Order.ASC;
@@ -181,31 +178,6 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
                 .where(senior.user.eq(seniorUser))
                 .fetchOne()
         );
-    }
-
-    @Override
-    public List<SeniorAndAccount> findAllSeniorAndAccount() {
-        List<Senior> seniors = queryFactory.selectFrom(senior)
-                .where(senior.user.isDelete.isFalse())
-                .fetch();
-        List<Account> accounts = queryFactory.selectFrom(account)
-                .distinct()
-                .where(account.senior.in(seniors))
-                .leftJoin(account.senior, senior)
-                .fetchJoin()
-                .fetch();
-
-        return seniors.stream()
-                .map(senior -> {
-                    Account account = accounts.stream()
-                            .filter(a -> a.getSenior().getSeniorId()
-                                    .equals(senior.getSeniorId())
-                            )
-                            .findFirst()
-                            .orElse(null);
-                    return new SeniorAndAccount(senior, account);
-                })
-                .toList();
     }
 
     @Override

--- a/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorGetService.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorGetService.java
@@ -1,6 +1,5 @@
 package com.postgraduate.domain.senior.domain.service;
 
-import com.postgraduate.domain.salary.application.dto.SeniorAndAccount;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.repository.SeniorRepository;
 import com.postgraduate.domain.senior.exception.NoneSeniorException;
@@ -20,11 +19,6 @@ import static java.lang.Boolean.FALSE;
 public class SeniorGetService {
     private final SeniorRepository seniorRepository;
     private static final int SENIOR_PAGE_SIZE = 10;
-    private static final int ADMIN_PAGE_SIZE = 15;
-
-    public List<SeniorAndAccount> findAllSeniorAndAccount() {
-        return seniorRepository.findAllSeniorAndAccount();
-    }
 
     public Senior byUser(User user) {
         return seniorRepository.findByUser(user).orElseThrow(NoneSeniorException::new);
@@ -38,12 +32,6 @@ public class SeniorGetService {
     public Senior bySeniorNickName(String nickName) {
         return seniorRepository.findByUser_NickNameAndUser_IsDelete(nickName, FALSE)
                 .orElseThrow(NoneSeniorException::new);
-    }
-
-    public Page<Senior> all(Integer page, String search) {
-        page = page == null ? 1 : page;
-        Pageable pageable = PageRequest.of(page - 1, ADMIN_PAGE_SIZE);
-        return seniorRepository.findAllBySearchSeniorWithAdmin(search, pageable);
     }
 
     public List<Senior> allSeniorId() {

--- a/src/main/java/com/postgraduate/domain/user/domain/entity/User.java
+++ b/src/main/java/com/postgraduate/domain/user/domain/entity/User.java
@@ -2,6 +2,8 @@ package com.postgraduate.domain.user.domain.entity;
 
 import com.postgraduate.domain.user.domain.entity.constant.Role;
 import jakarta.persistence.*;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +13,10 @@ import org.hibernate.annotations.*;
 import java.time.LocalDateTime;
 
 @Entity
+@Table(indexes = {
+        @Index(name = "user_nick_name_index", columnList = "nickName"),
+        @Index(name = "user_is_delete", columnList = "isDelete")
+})
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor


### PR DESCRIPTION
## 🦝 PR 요약
선배 분야 조회 및 검색 조회시 페이징 처리 최적화

## ✨ PR 상세 내용
- 커버링 인덱스 활용 선배 분야 조회 및 검색 조회시 페이징 처리 최적화
- totalInfo 길이 수정 -> 인덱스 설정을 위해

## 🚨 주의 사항
totalInfo -> Index 설정을 위해 text에서 varchar(500) 으로 변경
현재 사용자 기준, 가장 긴 totalIndex == 100자 -> 충분히 감당 가능 할 것으로 판단 하지만, 
필요에 따라 Index 최대 길이 수정 및 Text변경 가능

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
