### PR TITLE
RAC-403 fix : 선배 조회시 멘토링 진행 횟수 우선 정렬 수정

### DIFF
--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringApplyingUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringApplyingUseCase.java
@@ -12,6 +12,7 @@ import com.postgraduate.domain.mentoring.exception.MentoringDateException;
 import com.postgraduate.domain.payment.domain.entity.Payment;
 import com.postgraduate.domain.payment.domain.service.PaymentGetService;
 import com.postgraduate.domain.senior.domain.entity.Senior;
+import com.postgraduate.domain.senior.domain.service.SeniorUpdateService;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.global.bizppurio.application.usecase.BizppurioJuniorMessage;
 import com.postgraduate.global.bizppurio.application.usecase.BizppurioSeniorMessage;
@@ -26,6 +27,7 @@ import java.util.Optional;
 @Transactional
 public class MentoringApplyingUseCase {
     private final PaymentGetService paymentGetService;
+    private final SeniorUpdateService seniorUpdateService;
     private final MentoringGetService mentoringGetService;
     private final MentoringSaveService mentoringSaveService;
     private final AccountGetService accountGetService;
@@ -41,9 +43,14 @@ public class MentoringApplyingUseCase {
         Senior senior = payment.getSenior();
         Mentoring mentoring = MentoringMapper.mapToMentoring(user, senior, payment, request);
         mentoringSaveService.save(mentoring);
+        seniorUpdateService.plusMentoring(senior);
         Optional<Account> account = accountGetService.bySenior(senior);
+        sendMessage(user, senior);
+        return new ApplyingResponse(account.isPresent());
+    }
+
+    private void sendMessage(User user, Senior senior) {
         bizppurioJuniorMessage.mentoringApply(user);
         bizppurioSeniorMessage.mentoringApply(senior.getUser());
-        return new ApplyingResponse(account.isPresent());
     }
 }

--- a/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseCase.java
@@ -20,6 +20,7 @@ import com.postgraduate.domain.salary.domain.service.SalaryGetService;
 import com.postgraduate.domain.salary.domain.service.SalaryUpdateService;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
+import com.postgraduate.domain.senior.domain.service.SeniorUpdateService;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.global.bizppurio.application.usecase.BizppurioJuniorMessage;
 import com.postgraduate.global.bizppurio.application.usecase.BizppurioSeniorMessage;
@@ -47,6 +48,7 @@ public class MentoringManageUseCase {
     private final RefuseSaveService refuseSaveService;
     private final AccountGetService accountGetService;
     private final SeniorGetService seniorGetService;
+    private final SeniorUpdateService seniorUpdateService;
     private final SalaryGetService salaryGetService;
     private final SalaryUpdateService salaryUpdateService;
     private final PaymentManageUseCase paymentManageUseCase;
@@ -76,6 +78,7 @@ public class MentoringManageUseCase {
         Payment payment = mentoring.getPayment();
         paymentManageUseCase.refundPayByUser(user, payment.getOrderId());
         mentoringUpdateService.updateCancel(mentoring);
+        seniorUpdateService.minusMentoring(senior);
         bizppurioSeniorMessage.mentoringRefund(senior.getUser());
     }
 
@@ -98,6 +101,7 @@ public class MentoringManageUseCase {
         Payment payment = mentoring.getPayment();
         paymentManageUseCase.refundPayBySenior(senior, payment.getOrderId());
         mentoringUpdateService.updateRefuse(mentoring);
+        seniorUpdateService.minusMentoring(senior);
         bizppurioJuniorMessage.mentoringRefuse(mentoring.getUser());
     }
 

--- a/src/main/java/com/postgraduate/domain/senior/domain/entity/Info.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/entity/Info.java
@@ -39,7 +39,7 @@ public class Info {
     @Builder.Default
     private Boolean etcPostgradu = false;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, length = 500)
     private String totalInfo; // 모든 Info정보 String으로 가지는 컬럼 - 검색시 사용
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/com/postgraduate/domain/senior/domain/entity/Senior.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/entity/Senior.java
@@ -22,7 +22,8 @@ import static com.postgraduate.domain.senior.domain.entity.constant.Status.WAITI
         @Index(name = "senior_field_index", columnList = "field"),
         @Index(name = "senior_etc_field_index", columnList = "etcField"),
         @Index(name = "senior_postgradu_index", columnList = "postgradu"),
-        @Index(name = "senior_etc_postgradu_index", columnList = "etcPostgradu")
+        @Index(name = "senior_etc_postgradu_index", columnList = "etcPostgradu"),
+        @Index(name = "senior_mentoring_hit_index", columnList = "mentoringHit")
 })
 @Builder
 @AllArgsConstructor
@@ -47,6 +48,9 @@ public class Senior {
 
     @Column(nullable = false)
     private int hit;
+
+    @Column(nullable = false)
+    private int mentoringHit;
 
     @Embedded
     private Info info;
@@ -79,5 +83,13 @@ public class Senior {
 
     public void updateHit() {
         this.hit++;
+    }
+
+    public void plusMentoringHit() {
+        this.mentoringHit++;
+    }
+
+    public void minusMentoringHit() {
+        this.mentoringHit--;
     }
 }

--- a/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepositoryImpl.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/repository/SeniorDslRepositoryImpl.java
@@ -37,7 +37,7 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
 
     @Override
     public Page<Senior> findAllBySearchSenior(String search, String sort, Pageable pageable) {
-        List<Tuple> results = queryFactory.select(senior.seniorId, senior.user.nickName, senior.hit)
+        List<Tuple> results = queryFactory.select(senior.seniorId, senior.user.nickName, senior.hit, senior.mentoringHit)
                 .from(senior)
                 .distinct()
                 .leftJoin(senior.user, user)
@@ -46,7 +46,8 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
                                 .or(senior.user.nickName.like("%" + search + "%")),
                         senior.user.isDelete.eq(FALSE)
                 )
-                .orderBy(orderSpecifier(sort))
+                .orderBy(mentoringOrderSpecifier(sort))
+                .orderBy(hitOrderSpecifier(sort))
                 .orderBy(senior.user.nickName.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -62,7 +63,8 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
                         .toList()))
                 .leftJoin(senior.user, user)
                 .fetchJoin()
-                .orderBy(orderSpecifier(sort))
+                .orderBy(mentoringOrderSpecifier(sort))
+                .orderBy(hitOrderSpecifier(sort))
                 .orderBy(senior.user.nickName.asc())
                 .fetch();
 
@@ -81,7 +83,7 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
         return new PageImpl<>(seniors, pageable, total);
     }
 
-    private OrderSpecifier<?> orderSpecifier(String sort) {
+    private OrderSpecifier<?> hitOrderSpecifier(String sort) {
         if (sort == null)
             return new OrderSpecifier<>(DESC, senior.hit);
         if (sort.equals("low"))
@@ -89,9 +91,18 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
         return new OrderSpecifier<>(DESC, senior.hit);
     }
 
+    private OrderSpecifier<?> mentoringOrderSpecifier(String sort) {
+        if (sort == null)
+            return new OrderSpecifier<>(DESC, senior.mentoringHit);
+        if (sort.equals("low"))
+            return new OrderSpecifier<>(ASC, senior.mentoringHit);
+        return new OrderSpecifier<>(DESC, senior.mentoringHit);
+    }
+
+
     @Override
     public Page<Senior> findAllByFieldSenior(String field, String postgradu, Pageable pageable) {
-        List<Tuple> results = queryFactory.select(senior.seniorId, senior.user.nickName, senior.hit)
+        List<Tuple> results = queryFactory.select(senior.seniorId, senior.user.nickName, senior.hit, senior.mentoringHit)
                 .from(senior)
                 .distinct()
                 .leftJoin(senior.user, user)
@@ -100,6 +111,7 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
                         postgraduSpecifier(postgradu),
                         senior.user.isDelete.eq(FALSE)
                 )
+                .orderBy(senior.mentoringHit.desc())
                 .orderBy(senior.hit.desc())
                 .orderBy(senior.user.nickName.asc())
                 .offset(pageable.getOffset())
@@ -116,6 +128,7 @@ public class SeniorDslRepositoryImpl implements SeniorDslRepository{
                         .toList()))
                 .leftJoin(senior.user, user)
                 .fetchJoin()
+                .orderBy(senior.mentoringHit.desc())
                 .orderBy(senior.hit.desc())
                 .orderBy(senior.user.nickName.asc())
                 .fetch();

--- a/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorUpdateService.java
+++ b/src/main/java/com/postgraduate/domain/senior/domain/service/SeniorUpdateService.java
@@ -25,6 +25,14 @@ public class SeniorUpdateService {
         senior.updateInfo(info);
     }
 
+    public void plusMentoring(Senior senior) {
+        senior.plusMentoringHit();
+    }
+
+    public void minusMentoring(Senior senior) {
+        senior.minusMentoringHit();
+    }
+
     public void updateHit(Senior senior) {
         senior.updateHit();
     }

--- a/src/test/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseTypeTest.java
+++ b/src/test/java/com/postgraduate/domain/auth/application/usecase/oauth/SignUpUseTypeTest.java
@@ -86,7 +86,7 @@ class SignUpUseTypeTest {
                 1, USER, TRUE, LocalDateTime.now(), LocalDateTime.now(), FALSE);
         wish = new Wish(1L, "major", "field", TRUE, user, Status.WAITING);
         senior = new Senior(1L, user, "a",
-                APPROVE, 1, info, profile,
+                APPROVE,1, 1, info, profile,
                 LocalDateTime.now(), LocalDateTime.now());
     }
 

--- a/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringApplyingUseTypeTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringApplyingUseTypeTest.java
@@ -16,6 +16,7 @@ import com.postgraduate.domain.salary.domain.entity.Salary;
 import com.postgraduate.domain.senior.domain.entity.Info;
 import com.postgraduate.domain.senior.domain.entity.Profile;
 import com.postgraduate.domain.senior.domain.entity.Senior;
+import com.postgraduate.domain.senior.domain.service.SeniorUpdateService;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.global.bizppurio.application.usecase.BizppurioJuniorMessage;
 import com.postgraduate.global.bizppurio.application.usecase.BizppurioSeniorMessage;
@@ -54,6 +55,8 @@ class MentoringApplyingUseTypeTest {
     @Mock
     private AccountGetService accountGetService;
     @Mock
+    private SeniorUpdateService seniorUpdateService;
+    @Mock
     private BizppurioSeniorMessage bizppurioSeniorMessage;
     @Mock
     private BizppurioJuniorMessage bizppurioJuniorMessage;
@@ -80,7 +83,7 @@ class MentoringApplyingUseTypeTest {
                 "a", "123", "a",
                 0, USER, TRUE, LocalDateTime.now(), LocalDateTime.now(), TRUE);
         senior = new Senior(-1L, user, "a",
-                APPROVE, 1, info, profile,
+                APPROVE,1, 1, info, profile,
                 LocalDateTime.now(), LocalDateTime.now());
         salary = new Salary(-1L, FALSE, senior, 10000, LocalDate.now(), LocalDateTime.now(), null);
         account = new Account(-1L, "1", "은행", "유저", senior);

--- a/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseTypeTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringManageUseTypeTest.java
@@ -24,6 +24,7 @@ import com.postgraduate.domain.senior.domain.entity.Info;
 import com.postgraduate.domain.senior.domain.entity.Profile;
 import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorGetService;
+import com.postgraduate.domain.senior.domain.service.SeniorUpdateService;
 import com.postgraduate.domain.user.domain.entity.User;
 import com.postgraduate.global.bizppurio.application.usecase.BizppurioJuniorMessage;
 import com.postgraduate.global.bizppurio.application.usecase.BizppurioSeniorMessage;
@@ -65,6 +66,8 @@ class MentoringManageUseTypeTest {
     @Mock
     private SeniorGetService seniorGetService;
     @Mock
+    private SeniorUpdateService seniorUpdateService;
+    @Mock
     private SalaryGetService salaryGetService;
     @Mock
     private SalaryUpdateService salaryUpdateService;
@@ -103,7 +106,7 @@ class MentoringManageUseTypeTest {
                 "a", "123", "a",
                 0, USER, TRUE, LocalDateTime.now(), LocalDateTime.now(), TRUE);
         senior = new Senior(-1L, user, "a",
-                APPROVE, 1, info, profile,
+                APPROVE, 1, 1, info, profile,
                 LocalDateTime.now(), LocalDateTime.now());
         salary = new Salary(-1L, FALSE, senior, 10000, LocalDate.now(), LocalDateTime.now(), null);
         account = new Account(-1L, "1", "은행", "유저", senior);

--- a/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseTypeTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringSeniorInfoUseTypeTest.java
@@ -68,7 +68,7 @@ class MentoringSeniorInfoUseTypeTest {
                 "a", "123", "a",
                 0, USER, TRUE, LocalDateTime.now(), LocalDateTime.now(), TRUE);
         senior = new Senior(-1L, user, "a",
-                APPROVE, 1, info, profile,
+                APPROVE, 1, 1, info, profile,
                 LocalDateTime.now(), LocalDateTime.now());
         salary = new Salary(-1L, FALSE, senior, 10000, LocalDate.now(), LocalDateTime.now(), null);
         payment = new Payment(-1L, mentoringUser, senior, 20000, "a", "a", "a", LocalDateTime.now(), null, Status.DONE);

--- a/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseTypeTest.java
+++ b/src/test/java/com/postgraduate/domain/mentoring/application/usecase/MentoringUserInfoUseTypeTest.java
@@ -64,7 +64,7 @@ class MentoringUserInfoUseTypeTest {
                 "a", "123", "a",
                 0, USER, TRUE, LocalDateTime.now(), LocalDateTime.now(), TRUE);
         senior = new Senior(-1L, user, "a",
-                APPROVE, 1, info, profile,
+                APPROVE, 1,1, info, profile,
                 LocalDateTime.now(), LocalDateTime.now());
         salary = new Salary(-1L, FALSE, senior, 10000, LocalDate.now(), LocalDateTime.now(), null);
         payment = new Payment(-1L, mentoringUser, senior, 20000, "a", "a", "a", LocalDateTime.now(), null, Status.DONE);

--- a/src/test/java/com/postgraduate/domain/payment/usecase/PaymentManageUseTypeTest.java
+++ b/src/test/java/com/postgraduate/domain/payment/usecase/PaymentManageUseTypeTest.java
@@ -68,7 +68,7 @@ class PaymentManageUseTypeTest {
                 "a", "123", "a",
                 0, USER, TRUE, LocalDateTime.now(), LocalDateTime.now(), TRUE);
         senior = new Senior(-1L, user, "a",
-                APPROVE, 1, info, profile,
+                APPROVE, 1,1, info, profile,
                 LocalDateTime.now(), LocalDateTime.now());
     }
 

--- a/src/test/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseTypeTest.java
+++ b/src/test/java/com/postgraduate/domain/senior/application/usecase/SeniorInfoUseTypeTest.java
@@ -62,7 +62,7 @@ class SeniorInfoUseTypeTest {
                 "a", "12345", "a",
                 1, USER, TRUE, LocalDateTime.now(), LocalDateTime.now(), TRUE);
         senior = new Senior(1L, user, "a",
-                APPROVE, 1, info, profile,
+                APPROVE, 1, 1, info, profile,
                 LocalDateTime.now(), LocalDateTime.now());
     }
 
@@ -92,7 +92,7 @@ class SeniorInfoUseTypeTest {
     @DisplayName("검색어 기본 페이지 조회")
     void getSearchSeniorWithNull() {
         Senior otherSenior = new Senior(-2L, user, "a",
-                APPROVE, 1, info, profile,
+                APPROVE, 1, 1, info, profile,
                 LocalDateTime.now(), LocalDateTime.now());
         List<Senior> seniors = List.of(senior, otherSenior);
         Page<Senior> seniorPage = new PageImpl<>(seniors);
@@ -110,7 +110,7 @@ class SeniorInfoUseTypeTest {
     @DisplayName("검색어 페이지 조회")
     void getSearchSeniorWithPage() {
         Senior senior1 = new Senior(1L, user, "a",
-                APPROVE, 1, info, profile,
+                APPROVE, 1, 1, info, profile,
                 LocalDateTime.now(), LocalDateTime.now());
         List<Senior> seniors = List.of(senior, senior1);
         Page<Senior> seniorPage = new PageImpl<>(seniors);
@@ -128,7 +128,7 @@ class SeniorInfoUseTypeTest {
     @DisplayName("필터 기본 페이지 조회")
     void getFieldSeniorWithNull() {
         Senior senior1 = new Senior(1L, user, "a",
-                APPROVE, 1, info, profile,
+                APPROVE, 1, 1,info, profile,
                 LocalDateTime.now(), LocalDateTime.now());
         List<Senior> seniors = List.of(senior, senior1);
         Page<Senior> seniorPage = new PageImpl<>(seniors);
@@ -146,7 +146,7 @@ class SeniorInfoUseTypeTest {
     @DisplayName("필터 페이지 조회")
     void getFieldSeniorWithPage() {
         Senior senior1 = new Senior(1L, user, "a",
-                APPROVE, 1, info, profile,
+                APPROVE, 1, 1, info, profile,
                 LocalDateTime.now(), LocalDateTime.now());
         List<Senior> seniors = List.of(senior, senior1);
         Page<Senior> seniorPage = new PageImpl<>(seniors);

--- a/src/test/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseTypeTest.java
+++ b/src/test/java/com/postgraduate/domain/senior/application/usecase/SeniorManageUseTypeTest.java
@@ -91,7 +91,7 @@ class SeniorManageUseTypeTest {
                 "a", "123", "a",
                 1, SENIOR, TRUE, LocalDateTime.now(), LocalDateTime.now(), TRUE);
         senior = new Senior(1L, user, "a",
-                APPROVE, 1, info, profile,
+                APPROVE, 1, 1, info, profile,
                 LocalDateTime.now(), LocalDateTime.now());
     }
 

--- a/src/test/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseTypeTest.java
+++ b/src/test/java/com/postgraduate/domain/senior/application/usecase/SeniorMyPageUseTypeTest.java
@@ -69,14 +69,14 @@ class SeniorMyPageUseTypeTest {
                 "a", "123", "a",
                 1, USER, TRUE, LocalDateTime.now(), LocalDateTime.now(), TRUE);
         senior = new Senior(1L, user, "a",
-                APPROVE, 1, info, profile,
+                APPROVE, 1, 1, info, profile,
                 LocalDateTime.now(), LocalDateTime.now());
     }
 
     @Test
     @DisplayName("Profile Null 선배 자신의 정보 조회")
     void getSeniorInfoWithNullProfile() {
-        senior = new Senior(1L, user, "a", WAITING, 1, info, null, LocalDateTime.now(), LocalDateTime.now());
+        senior = new Senior(1L, user, "a", WAITING, 1, 1, info, null, LocalDateTime.now(), LocalDateTime.now());
 
         given(seniorGetService.byUser(user))
                 .willReturn(senior);
@@ -121,7 +121,7 @@ class SeniorMyPageUseTypeTest {
     @Test
     @DisplayName("선배 자신의 마이페이지 프로필 작성 이전 Info조회 테스트")
     void getSeniorMyPageProfileWithNull() {
-        Senior nullSenior = new Senior(-2L, user, "asd", APPROVE, 1, info, null, LocalDateTime.now(), null);
+        Senior nullSenior = new Senior(-2L, user, "asd", APPROVE, 1, 1, info, null, LocalDateTime.now(), null);
         given(seniorGetService.byUser(user))
                 .willReturn(nullSenior);
 

--- a/src/test/java/com/postgraduate/domain/senior/domain/service/SeniorUpdateServiceTest.java
+++ b/src/test/java/com/postgraduate/domain/senior/domain/service/SeniorUpdateServiceTest.java
@@ -33,7 +33,7 @@ class SeniorUpdateServiceTest {
     private Senior senior;
     @BeforeEach
     void setting() {
-        senior = new Senior(1L, user, "a", Status.WAITING, 100, new Info(), new Profile(), now(), now());
+        senior = new Senior(1L, user, "a", Status.WAITING, 1, 100, new Info(), new Profile(), now(), now());
     }
 
     @Test

--- a/src/test/java/com/postgraduate/support/Resource.java
+++ b/src/test/java/com/postgraduate/support/Resource.java
@@ -32,8 +32,8 @@ public class Resource {
     private User userOfSenior = new User(-2L, -2L, "mail", "선배", "012", "profile", 0, SENIOR, true, now(), now(), false);
     private Info info = new Info("major", "서울대학교", "교수님", "키워드1,키워드2", "랩실", "인공지능", false, false, "인공지능,키워드1,키워드2", "chatLink", 30);
     private Profile profile = new Profile("저는요", "한줄소개", "대상");
-    private Senior senior = new Senior(-1L, userOfSenior, "certification", com.postgraduate.domain.senior.domain.entity.constant.Status.WAITING, 0, info, profile, now(), now());
-    private Senior otherSenior = new Senior(-3L, otherUser, "certification", com.postgraduate.domain.senior.domain.entity.constant.Status.WAITING, 0, info, null, now(), now());
+    private Senior senior = new Senior(-1L, userOfSenior, "certification", com.postgraduate.domain.senior.domain.entity.constant.Status.WAITING, 0, 0, info, profile, now(), now());
+    private Senior otherSenior = new Senior(-3L, otherUser, "certification", com.postgraduate.domain.senior.domain.entity.constant.Status.WAITING, 0, 0, info, null, now(), now());
     private SalaryAccount salaryAccount = new SalaryAccount("bank", "1234", "holder");
     private Salary salary = new Salary(-1L, false, senior, 20000, getSalaryDate(), LocalDateTime.now(), salaryAccount);
     private Payment payment = new Payment(-1L, user, senior, 20000, "1", "123", "123", LocalDateTime.now(), LocalDateTime.now(), DONE);


### PR DESCRIPTION
## 🦝 PR 요약
선배 조회시 멘토링 진행 횟수 우선 정렬

## ✨ PR 상세 내용
- Senior 테이블에 mentoringHit 컬럼 추가 및 인덱스 설정
- 선배 조회시, mentoringHit 우선 정렬 후 조회수 정렬 및 ㄱㄴㄷ순 정렬
- 멘토링 신청 및 취소시 mentoringHit 업데이트 추가

## 🚨 주의 사항
Mentoring 의 senior count를 통해 order by를 설정하는 것 보다, mentoringHit 컬럼 추가 및 인덱스 처리를 통해 빠른 정렬 가능할 것이라 생각하여 Senior 테이블 수정하여 기능 추가함

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
