### PR TITLE
RAC-402 feat : 탈퇴 로직 수정 및 이후 플로우 작성

### DIFF
--- a/src/main/java/com/postgraduate/domain/auth/application/dto/req/RejoinRequest.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/dto/req/RejoinRequest.java
@@ -1,0 +1,3 @@
+package com.postgraduate.domain.auth.application.dto.req;
+
+public record RejoinRequest(long socialId, boolean rejoin) {}

--- a/src/main/java/com/postgraduate/domain/auth/application/dto/res/AuthUserResponse.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/dto/res/AuthUserResponse.java
@@ -2,8 +2,16 @@ package com.postgraduate.domain.auth.application.dto.res;
 
 import com.postgraduate.domain.user.user.domain.entity.User;
 
-public record AuthUserResponse(User user, Long socialId) implements AuthResponse{
+public record AuthUserResponse(User user, Long socialId, Boolean isDelete) implements AuthResponse{
     public AuthUserResponse(Long socialId) {
-        this(null, socialId);
+        this(null, socialId, false);
+    }
+
+    public AuthUserResponse(User user, Long socialId) {
+        this(user, socialId, false);
+    }
+
+    public AuthUserResponse(Long socialId, boolean isDelete) {
+        this(null, socialId, isDelete);
     }
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/mapper/AuthMapper.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/mapper/AuthMapper.java
@@ -11,6 +11,10 @@ public class AuthMapper {
         return new AuthUserResponse(user, socialId);
     }
 
+    public static AuthUserResponse mapToAuthUser(Long socialId, boolean isDelete) {
+        return new AuthUserResponse(socialId, isDelete);
+    }
+
     public static AuthUserResponse mapToAuthUser(Long socialId) {
         return new AuthUserResponse(socialId);
     }

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignOutUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignOutUseCase.java
@@ -1,5 +1,8 @@
 package com.postgraduate.domain.auth.application.usecase.oauth;
 
+import com.postgraduate.domain.auth.application.dto.req.SignOutRequest;
+import com.postgraduate.domain.user.user.domain.entity.User;
+
 public interface SignOutUseCase {
-    void signOut(Long userId);
+    void signOut(User user, SignOutRequest signOutRequest);
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignOutUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/SignOutUseCase.java
@@ -5,4 +5,6 @@ import com.postgraduate.domain.user.user.domain.entity.User;
 
 public interface SignOutUseCase {
     void signOut(User user, SignOutRequest signOutRequest);
+
+    void reSignOut(Long socialId);
 }

--- a/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignOutUseCase.java
+++ b/src/main/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignOutUseCase.java
@@ -62,6 +62,23 @@ public class KakaoSignOutUseCase implements SignOutUseCase {
         }
     }
 
+    @Override
+    public void reSignOut(Long socialId) {
+        try {
+            MultiValueMap<String, String> requestBody = getRequestBody(socialId);
+            webClient.post()
+                    .uri(KAKAO_UNLINK_URI)
+                    .headers(h -> h.setContentType(MediaType.APPLICATION_FORM_URLENCODED))
+                    .headers(h -> h.set(HttpHeaders.AUTHORIZATION, AUTHORIZATION + ADMIN_ID))
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+        } catch (WebClientResponseException ex) {
+            throw new KakaoException();
+        }
+    }
+
     private void updateDelete(User user, SignOutRequest signOutRequest) {
         user = userGetService.byUserId(user.getUserId());
         checkDeleteCondition(user);

--- a/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
@@ -5,11 +5,11 @@ import com.postgraduate.domain.auth.application.dto.res.AuthResponse;
 import com.postgraduate.domain.auth.application.dto.res.AuthUserResponse;
 import com.postgraduate.domain.auth.application.dto.res.JwtTokenResponse;
 import com.postgraduate.domain.auth.application.usecase.oauth.SelectOauth;
+import com.postgraduate.domain.auth.application.usecase.oauth.SignOutUseCase;
 import com.postgraduate.domain.auth.application.usecase.oauth.SignUpUseCase;
 import com.postgraduate.domain.auth.application.usecase.jwt.JwtUseCase;
 import com.postgraduate.domain.auth.application.usecase.oauth.SignInUseCase;
 import com.postgraduate.domain.auth.presentation.constant.Provider;
-import com.postgraduate.domain.user.quit.application.usecase.QuitManageUseCase;
 import com.postgraduate.domain.user.user.domain.entity.User;
 import com.postgraduate.global.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,7 +34,6 @@ import static com.postgraduate.global.dto.ResponseDto.create;
 public class AuthController {
     private final SelectOauth selectOauth;
     private final SignUpUseCase signUpUseCase;
-    private final QuitManageUseCase quitManageUseCase;
     private final JwtUseCase jwtUseCase;
 
     @PostMapping("/login/token/{provider}")
@@ -95,7 +94,7 @@ public class AuthController {
     @PostMapping("/user/change")
     @Operation(summary = "후배로 추가 가입 | 토큰 필요", description = "대학원생 대학생으로 변경 추가 가입")
     public ResponseEntity<ResponseDto<JwtTokenResponse>> changeUser(@AuthenticationPrincipal User user,
-                                                    @RequestBody @Valid UserChangeRequest changeRequest) {
+                                                                    @RequestBody @Valid UserChangeRequest changeRequest) {
         signUpUseCase.changeUser(user, changeRequest);
         JwtTokenResponse jwtToken = jwtUseCase.changeUser(user);
         return ResponseEntity.ok(create(AUTH_CREATE.getCode(), SUCCESS_AUTH.getMessage(), jwtToken));
@@ -112,7 +111,7 @@ public class AuthController {
     @PostMapping("/senior/change")
     @Operation(summary = "선배로 추가 가입 | 토큰 필요", description = "대학생 대학원생으로 변경 추가 가입")
     public ResponseEntity<ResponseDto<JwtTokenResponse>> changeSenior(@AuthenticationPrincipal User user,
-                                                      @RequestBody @Valid SeniorChangeRequest changeRequest) {
+                                                                      @RequestBody @Valid SeniorChangeRequest changeRequest) {
         User changeUser = signUpUseCase.changeSenior(user, changeRequest);
         JwtTokenResponse jwtToken = jwtUseCase.changeSenior(changeUser);
         return ResponseEntity.ok(create(SENIOR_CREATE.getCode(), CREATE_SENIOR.getMessage(), jwtToken));
@@ -132,11 +131,11 @@ public class AuthController {
         return ResponseEntity.ok(create(AUTH_UPDATE.getCode(), SUCCESS_REGENERATE_TOKEN.getMessage(), jwtToken));
     }
 
-    @PostMapping("/signout")
+    @PostMapping("/signout/{provider}")
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 진행")
-    public ResponseEntity<ResponseDto<Void>> signOut(@AuthenticationPrincipal User user, @RequestBody SignOutRequest signOutRequest) {
-        quitManageUseCase.updateDelete(user, signOutRequest);
+    public ResponseEntity<ResponseDto<Void>> signOut(@AuthenticationPrincipal User user, @RequestBody SignOutRequest signOutRequest, @PathVariable Provider provider) {
+        SignOutUseCase signOutUseCase = selectOauth.selectSignOut(provider);
+        signOutUseCase.signOut(user, signOutRequest);
         return ResponseEntity.ok(create(AUTH_DELETE.getCode(), SIGNOUT_USER.getMessage()));
     }
-
 }

--- a/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
@@ -10,6 +10,7 @@ import com.postgraduate.domain.auth.application.usecase.oauth.SignUpUseCase;
 import com.postgraduate.domain.auth.application.usecase.jwt.JwtUseCase;
 import com.postgraduate.domain.auth.application.usecase.oauth.SignInUseCase;
 import com.postgraduate.domain.auth.presentation.constant.Provider;
+import com.postgraduate.domain.user.user.application.usecase.UserManageUseCase;
 import com.postgraduate.domain.user.user.domain.entity.User;
 import com.postgraduate.global.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,6 +36,7 @@ public class AuthController {
     private final SelectOauth selectOauth;
     private final SignUpUseCase signUpUseCase;
     private final JwtUseCase jwtUseCase;
+    private final UserManageUseCase userManageUseCase;
 
     @PostMapping("/login/token/{provider}")
     @Operation(summary = "소셜 로그인", description = "회원인 경우 JWT를, 회원이 아닌 경우 socialId를 반환합니다(회원가입은 진행하지 않습니다).")
@@ -66,6 +68,14 @@ public class AuthController {
         if (authUser.user() == null)
             return ResponseEntity.ok(create(AUTH_NONE.getCode(), NOT_REGISTERED_USER.getMessage(), authUser));
         JwtTokenResponse jwtToken = jwtUseCase.signIn(authUser.user());
+        return ResponseEntity.ok(create(AUTH_ALREADY.getCode(), SUCCESS_AUTH.getMessage(), jwtToken));
+    }
+
+    @PatchMapping("/rejoin/{provider}")
+    @Operation(summary = "탈퇴 사용자 재가입", description = "회원인 경우 JWT를, 회원이 아닌 경우 socialId를 반환합니다(회원가입은 진행하지 않습니다).")
+    public ResponseEntity<ResponseDto<AuthResponse>> reJoin(@PathVariable Provider provider, @RequestBody RejoinRequest request) {
+        User user = userManageUseCase.updateRejoin(provider, request);
+        JwtTokenResponse jwtToken = jwtUseCase.signIn(user);
         return ResponseEntity.ok(create(AUTH_ALREADY.getCode(), SUCCESS_AUTH.getMessage(), jwtToken));
     }
 

--- a/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/postgraduate/domain/auth/presentation/AuthController.java
@@ -39,7 +39,7 @@ public class AuthController {
     private final UserManageUseCase userManageUseCase;
 
     @PostMapping("/login/token/{provider}")
-    @Operation(summary = "소셜 로그인", description = "회원인 경우 JWT를, 회원이 아닌 경우 socialId를 반환합니다(회원가입은 진행하지 않습니다).")
+    @Operation(summary = "소셜 로그인", description = "회원인 경우 JWT를, 회원이 아닌 경우 socialId를 반환합니다(회원가입은 진행하지 않습니다). 탈퇴 회원인 경우 isDelete = true 가 응답됩니다")
     public ResponseEntity<ResponseDto<AuthResponse>> authLoginWithToken(@RequestBody @Valid TokenRequest request, @PathVariable Provider provider) {
         SignInUseCase signInUseCase = selectOauth.selectSignIn(provider);
         AuthUserResponse authUser = signInUseCase.getUserWithToken(request);
@@ -50,7 +50,7 @@ public class AuthController {
     }
 
     @PostMapping("/login/{provider}")
-    @Operation(summary = "소셜 로그인", description = "회원인 경우 JWT를, 회원이 아닌 경우 socialId를 반환합니다(회원가입은 진행하지 않습니다).")
+    @Operation(summary = "소셜 로그인", description = "회원인 경우 JWT를, 회원이 아닌 경우 socialId를 반환합니다(회원가입은 진행하지 않습니다). 탈퇴 회원인 경우 isDelete = true 가 응답됩니다")
     public ResponseEntity<ResponseDto<AuthResponse>> authLogin(@RequestBody @Valid CodeRequest request, @PathVariable Provider provider) {
         SignInUseCase signInUseCase = selectOauth.selectSignIn(provider);
         AuthUserResponse authUser = signInUseCase.getUser(request);
@@ -61,7 +61,7 @@ public class AuthController {
     }
 
     @PostMapping("/dev/login/{provider}")
-    @Operation(summary = "개발용 소셜 로그인", description = "회원인 경우 JWT를, 회원이 아닌 경우 socialId를 반환합니다(회원가입은 진행하지 않습니다).")
+    @Operation(summary = "개발용 소셜 로그인", description = "회원인 경우 JWT를, 회원이 아닌 경우 socialId를 반환합니다(회원가입은 진행하지 않습니다). 탈퇴 회원인 경우 isDelete = true 가 응답됩니다")
     public ResponseEntity<ResponseDto<AuthResponse>> authDevLogin(@RequestBody @Valid CodeRequest request, @PathVariable Provider provider) {
         SignInUseCase signInUseCase = selectOauth.selectSignIn(provider);
         AuthUserResponse authUser = signInUseCase.getDevUser(request);
@@ -72,7 +72,7 @@ public class AuthController {
     }
 
     @PatchMapping("/rejoin/{provider}")
-    @Operation(summary = "탈퇴 사용자 재가입", description = "회원인 경우 JWT를, 회원이 아닌 경우 socialId를 반환합니다(회원가입은 진행하지 않습니다).")
+    @Operation(summary = "탈퇴 사용자 재가입", description = "복구를 희망하는 경우 rejoin = true 희망하지 않는 경우 false 를 넣어주세요. 복구시 기존 로그인과 동일한 응답")
     public ResponseEntity<ResponseDto<AuthResponse>> reJoin(@PathVariable Provider provider, @RequestBody RejoinRequest request) {
         User user = userManageUseCase.updateRejoin(provider, request);
         JwtTokenResponse jwtToken = jwtUseCase.signIn(user);

--- a/src/main/java/com/postgraduate/domain/user/quit/application/mapper/QuitMapper.java
+++ b/src/main/java/com/postgraduate/domain/user/quit/application/mapper/QuitMapper.java
@@ -21,6 +21,6 @@ public class QuitMapper {
     private static QuitBuilder getBuilder(User user, SignOutRequest request) {
         return Quit.builder()
                 .role(user.getRole())
-                .reason(request.reason());
+                .reason(request.reason().getReason());
     }
 }

--- a/src/main/java/com/postgraduate/domain/user/quit/application/usecase/QuitManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/user/quit/application/usecase/QuitManageUseCase.java
@@ -1,19 +1,9 @@
 package com.postgraduate.domain.user.quit.application.usecase;
 
-import com.postgraduate.domain.auth.application.dto.req.SignOutRequest;
-import com.postgraduate.domain.senior.domain.entity.Senior;
 import com.postgraduate.domain.senior.domain.service.SeniorDeleteService;
-import com.postgraduate.domain.senior.domain.service.SeniorGetService;
-import com.postgraduate.domain.user.quit.application.mapper.QuitMapper;
-import com.postgraduate.domain.user.quit.application.utils.QuitUtils;
-import com.postgraduate.domain.user.quit.domain.entity.Quit;
 import com.postgraduate.domain.user.user.domain.entity.User;
-import com.postgraduate.domain.user.user.domain.entity.constant.Role;
-import com.postgraduate.domain.user.quit.domain.service.QuitSaveService;
 import com.postgraduate.domain.user.user.domain.service.UserDeleteService;
 import com.postgraduate.domain.user.user.domain.service.UserGetService;
-import com.postgraduate.domain.user.user.domain.service.UserUpdateService;
-import com.postgraduate.domain.user.user.exception.DeletedUserException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -27,30 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuitManageUseCase {
     private final UserGetService userGetService;
     private final UserDeleteService userDeleteService;
-    private final UserUpdateService userUpdateService;
-    private final SeniorGetService seniorGetService;
     private final SeniorDeleteService seniorDeleteService;
-    private final QuitSaveService quitSaveService;
-    private final QuitUtils quitUtils;
-
-    public void updateDelete(User user, SignOutRequest signOutRequest) {
-        user = userGetService.byUserId(user.getUserId());
-        checkDeleteCondition(user);
-        Quit quit = QuitMapper.mapToQuit(user, signOutRequest);
-        quitSaveService.save(quit);
-        userUpdateService.updateDelete(user);
-    }
-
-    private void checkDeleteCondition(User user) {
-        if (user.isDelete())
-            throw new DeletedUserException();
-        if (user.getRole().equals(Role.SENIOR)) {
-            Senior senior = seniorGetService.byUser(user);
-            quitUtils.checkDeleteCondition(senior);
-            return;
-        }
-        quitUtils.checkDeleteCondition(user);
-    }
 
     @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
     public void updateRealDelete() {

--- a/src/main/java/com/postgraduate/domain/user/quit/domain/entity/Quit.java
+++ b/src/main/java/com/postgraduate/domain/user/quit/domain/entity/Quit.java
@@ -1,6 +1,5 @@
 package com.postgraduate.domain.user.quit.domain.entity;
 
-import com.postgraduate.domain.user.quit.domain.entity.constant.QuitReason;
 import com.postgraduate.domain.user.user.domain.entity.constant.Role;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -18,8 +17,7 @@ public class Quit {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long quitId;
 
-    @Enumerated(EnumType.STRING)
-    private QuitReason reason;
+    private String reason;
 
     private String etc;
 

--- a/src/main/java/com/postgraduate/domain/user/user/application/usecase/UserManageUseCase.java
+++ b/src/main/java/com/postgraduate/domain/user/user/application/usecase/UserManageUseCase.java
@@ -1,10 +1,16 @@
 package com.postgraduate.domain.user.user.application.usecase;
 
+import com.postgraduate.domain.auth.application.dto.req.RejoinRequest;
+import com.postgraduate.domain.auth.application.usecase.oauth.SelectOauth;
+import com.postgraduate.domain.auth.application.usecase.oauth.SignOutUseCase;
+import com.postgraduate.domain.auth.presentation.constant.Provider;
 import com.postgraduate.domain.user.user.application.dto.req.UserInfoRequest;
 import com.postgraduate.domain.user.user.application.utils.UserUtils;
 import com.postgraduate.domain.user.user.domain.entity.User;
 import com.postgraduate.domain.user.user.domain.service.UserGetService;
 import com.postgraduate.domain.user.user.domain.service.UserUpdateService;
+import com.postgraduate.domain.user.user.exception.DeletedUserException;
+import com.postgraduate.domain.user.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +22,7 @@ public class UserManageUseCase {
     private final UserUpdateService userUpdateService;
     private final UserGetService userGetService;
     private final UserUtils userUtils;
+    private final SelectOauth selectOauth;
 
     public void updateInfo(User user, UserInfoRequest userInfoRequest) {
         userUtils.checkPhoneNumber(userInfoRequest.phoneNumber());
@@ -31,5 +38,18 @@ public class UserManageUseCase {
     @Transactional(readOnly = true)
     public Boolean duplicatedNickName(String nickName) {
         return userGetService.byNickName(nickName).isEmpty();
+    }
+
+    public User updateRejoin(Provider provider, RejoinRequest request) {
+        User user = userGetService.bySocialId(request.socialId());
+        if (!user.isDelete())
+            throw new UserNotFoundException();
+        if (!request.rejoin() || user.isRealDelete()) {
+            SignOutUseCase signOutUseCase = selectOauth.selectSignOut(provider);
+            signOutUseCase.reSignOut(request.socialId());
+            throw new DeletedUserException();
+        }
+        userUpdateService.updateRestore(user);
+        return user;
     }
 }

--- a/src/main/resources/db/migration/V1_202408230342__modifyColumn.sql
+++ b/src/main/resources/db/migration/V1_202408230342__modifyColumn.sql
@@ -1,0 +1,1 @@
+ALTER TABLE quit MODIFY reason varchar(255);

--- a/src/test/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignInUseTypeTest.java
+++ b/src/test/java/com/postgraduate/domain/auth/application/usecase/oauth/kakao/KakaoSignInUseTypeTest.java
@@ -20,6 +20,7 @@ import java.time.LocalDateTime;
 
 import static com.postgraduate.domain.auth.application.dto.res.KakaoUserInfoResponse.KakaoAccount;
 import static com.postgraduate.domain.user.user.domain.entity.constant.Role.USER;
+import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.mockito.BDDMockito.given;
 
@@ -31,6 +32,8 @@ class KakaoSignInUseTypeTest {
     private UserGetService userGetService;
     @Mock
     private UserUpdateService userUpdateService;
+    @Mock
+    private KakaoSignOutUseCase kakaoSignOutUseCase;
     @InjectMocks
     private KakaoSignInUseCase kakaoSignInUseCase;
 
@@ -40,7 +43,7 @@ class KakaoSignInUseTypeTest {
     void setting() {
         user = new User(1L, 1L, "a",
                 "a", "123", "a",
-                1, USER, TRUE, LocalDateTime.now(), LocalDateTime.now(), TRUE, TRUE);
+                1, USER, TRUE, LocalDateTime.now(), LocalDateTime.now(), TRUE, FALSE);
     }
     @Test
     @DisplayName("기존 회원 테스트")


### PR DESCRIPTION
## 🦝 PR 요약
탈퇴 로직 수정 및 이후 플로우 작성

## ✨ PR 상세 내용
- 탈퇴 사유 저장시 문자열로 변경
- 탈퇴시 소셜 연결 해제
- 탈퇴 회원 로그인시 isDelete 추가
- 회원 복구 API 추가
true -> 복구
false -> 소셜 해지

## 🚨 주의 사항
- 탈퇴 회원 추가로 인한 로그인 관련 응답 변경
-> 이후 로그인 로직 확정시 전체적으로 변경 가능

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
