### PR TITLE
RAC-449 feat : 500에러 탐지시 슬랙 발송 추가

### DIFF
--- a/src/main/java/com/postgraduate/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/postgraduate/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.postgraduate.global.exception;
 import com.postgraduate.global.constant.ErrorCode;
 import com.postgraduate.global.dto.ErrorResponse;
 import com.postgraduate.global.dto.ResponseDto;
+import com.postgraduate.global.slack.SlackErrorMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import static com.postgraduate.global.dto.ResponseDto.create;
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
     private static final String LOG_FORMAT = "Code : {}, Message : {}";
+    private final SlackErrorMessage slackErrorMessage;
 
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<ResponseDto<ErrorResponse>> handleApplicationException(ApplicationException ex) {
@@ -34,6 +36,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ResponseDto<ErrorResponse>> handleInternalServerException(Exception ex) {
         log.error(LOG_FORMAT, "500", ex.getStackTrace());
         log.error("errorMessage : {}", ex.getMessage());
+        log.error("stackTrace : {}", ex.getStackTrace());
+        slackErrorMessage.sendSlackServerError(ex);
         return ResponseEntity.internalServerError().build();
     }
 }

--- a/src/main/java/com/postgraduate/global/slack/SlackErrorMessage.java
+++ b/src/main/java/com/postgraduate/global/slack/SlackErrorMessage.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.postgraduate.global.slack.SlackUtils.generateSlackField;
@@ -63,6 +64,19 @@ public class SlackErrorMessage {
         }
     }
 
+    public void sendSlackServerError(Exception ex) {
+        try {
+            slackClient.send(logWebHookUrl, Payload.builder()
+                    .text("알림톡 발송 실패! 확인 요망!!")
+                    .attachments(
+                            List.of(generateServerErrorSlackAttachMent(ex))
+                    )
+                    .build());
+        } catch (IOException e) {
+            log.error("slack 전송 오류");
+        }
+    }
+
     private Attachment generateMentoringErrorSlackAttachment(Long mentoringId, Throwable ex) {
         String requestTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:SS").format(LocalDateTime.now());
         return Attachment.builder()
@@ -94,6 +108,18 @@ public class SlackErrorMessage {
                 .title(requestTime + "에 발생한 알림톡 발송 실패")
                 .fields(List.of(
                         generateSlackField("알림톡 발송 실패, 수신 번호", phoneNumber)
+                ))
+                .build();
+    }
+
+    private Attachment generateServerErrorSlackAttachMent(Exception ex) {
+        String requestTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:SS").format(LocalDateTime.now());
+        return Attachment.builder()
+                .color("ff0000")
+                .title(requestTime + "에 발생한 500 에러")
+                .fields(List.of(
+                        generateSlackField("500 에러 발생", ex.getMessage()),
+                        generateSlackField("StackTrace", Arrays.toString(ex.getStackTrace()))
                 ))
                 .build();
     }


### PR DESCRIPTION
## 🦝 PR 요약
500에러 탐지시 슬랙 발송 추가

## ✨ PR 상세 내용
GlobalExceptionHandler 에서 500 발생 처리하는 곳에서 Slack에 웹훅 발송하도록 추가

## 🚨 주의 사항
주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
