### PR TITLE
RAC-449 feat : 500에러 탐지시 슬랙 발송 추가

### DIFF
--- a/src/main/java/com/postgraduate/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/postgraduate/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.postgraduate.global.exception;
 import com.postgraduate.global.constant.ErrorCode;
 import com.postgraduate.global.dto.ErrorResponse;
 import com.postgraduate.global.dto.ResponseDto;
+import com.postgraduate.global.slack.SlackErrorMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import static com.postgraduate.global.dto.ResponseDto.create;
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
     private static final String LOG_FORMAT = "Code : {}, Message : {}";
+    private final SlackErrorMessage slackErrorMessage;
 
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<ResponseDto<ErrorResponse>> handleApplicationException(ApplicationException ex) {
@@ -34,6 +36,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ResponseDto<ErrorResponse>> handleInternalServerException(Exception ex) {
         log.error(LOG_FORMAT, "500", ex.getStackTrace());
         log.error("errorMessage : {}", ex.getMessage());
+        slackErrorMessage.sendSlackServerError(ex);
         return ResponseEntity.internalServerError().build();
     }
 }

--- a/src/main/java/com/postgraduate/global/slack/SlackErrorMessage.java
+++ b/src/main/java/com/postgraduate/global/slack/SlackErrorMessage.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.postgraduate.global.slack.SlackUtils.generateSlackField;
@@ -63,6 +64,19 @@ public class SlackErrorMessage {
         }
     }
 
+    public void sendSlackServerError(Exception ex) {
+        try {
+            slackClient.send(logWebHookUrl, Payload.builder()
+                    .text("알림톡 발송 실패! 확인 요망!!")
+                    .attachments(
+                            List.of(generateServerErrorSlackAttachMent(ex))
+                    )
+                    .build());
+        } catch (IOException e) {
+            log.error("slack 전송 오류");
+        }
+    }
+
     private Attachment generateMentoringErrorSlackAttachment(Long mentoringId, Throwable ex) {
         String requestTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:SS").format(LocalDateTime.now());
         return Attachment.builder()
@@ -74,7 +88,6 @@ public class SlackErrorMessage {
                 ))
                 .build();
     }
-
     private Attachment generateSalaryErrorSlackAttachment(Long seniorId, Throwable ex) {
         String requestTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:SS").format(LocalDateTime.now());
         return Attachment.builder()
@@ -86,7 +99,6 @@ public class SlackErrorMessage {
                 ))
                 .build();
     }
-
     private Attachment generateBizppurioErrorSlackAttachment(String phoneNumber) {
         String requestTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:SS").format(LocalDateTime.now());
         return Attachment.builder()
@@ -94,6 +106,18 @@ public class SlackErrorMessage {
                 .title(requestTime + "에 발생한 알림톡 발송 실패")
                 .fields(List.of(
                         generateSlackField("알림톡 발송 실패, 수신 번호", phoneNumber)
+                ))
+                .build();
+    }
+
+    private Attachment generateServerErrorSlackAttachMent(Exception ex) {
+        String requestTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:SS").format(LocalDateTime.now());
+        return Attachment.builder()
+                .color("ff0000")
+                .title(requestTime + "에 발생한 500 에러")
+                .fields(List.of(
+                        generateSlackField("500 에러 발생", ex.getMessage()),
+                        generateSlackField("StackTrace", Arrays.toString(ex.getStackTrace()))
                 ))
                 .build();
     }

--- a/src/test/java/com/postgraduate/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/postgraduate/domain/user/presentation/UserControllerTest.java
@@ -87,30 +87,6 @@ class UserControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.message").value(UPDATE_USER_INFO.getMessage()));
     }
 
-    @Test
-    @DisplayName("잘못된 번호로 수정할 수 없다")
-    @WithMockUser
-    void updateInvalidPhoneNumber() throws Exception {
-        UserInfoRequest userInfoRequest = new UserInfoRequest("new_profile", "new후배", "phoneNumber");
-        String request = objectMapper.writeValueAsString(
-                userInfoRequest
-        );
-
-        willThrow(new PhoneNumberException())
-                .given(userManageUseCase)
-                .updateInfo(any(), any());
-
-        mvc.perform(patch("/user/me/info")
-                        .with(csrf())
-                        .header(HttpHeaders.AUTHORIZATION, BEARER )
-                        .content(request)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(UserResponseCode.INVALID_PHONE_NUMBER.getCode()))
-                .andExpect(jsonPath("$.message").value(UserResponseMessage.INVALID_PHONE_NUMBER.getMessage()));
-    }
-
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @WithMockUser

--- a/src/test/java/com/postgraduate/support/ControllerTest.java
+++ b/src/test/java/com/postgraduate/support/ControllerTest.java
@@ -21,6 +21,7 @@ import com.postgraduate.domain.member.user.application.usecase.UserManageUseCase
 import com.postgraduate.domain.member.user.application.usecase.UserMyPageUseCase;
 import com.postgraduate.domain.member.user.presentation.UserController;
 import com.postgraduate.global.aop.lock.DistributeLockAspect;
+import com.postgraduate.global.exception.GlobalExceptionHandler;
 import com.postgraduate.global.slack.SlackLogErrorMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -79,6 +80,8 @@ public class ControllerTest {
     protected SlackLogErrorMessage slackLogErrorMessage;
     @MockBean
     protected DistributeLockAspect distributeLockAspect;
+    @MockBean
+    protected GlobalExceptionHandler globalExceptionHandler;
     protected Resource resource = new Resource();
 
 }


### PR DESCRIPTION
## 🦝 PR 요약
500에러 탐지시 슬랙 발송 추가

## ✨ PR 상세 내용
globalExceptionHandler에서 500 발생시 slack에 전파하도록 추가

## 🚨 주의 사항
주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
