### PR TITLE
RAC-452 HotFix : 후배 가입(추가가입)시 토큰 발급 오류 해결

### DIFF
--- a/src/main/java/com/postgraduate/domain/member/user/domain/entity/User.java
+++ b/src/main/java/com/postgraduate/domain/member/user/domain/entity/User.java
@@ -72,6 +72,10 @@ public class User {
     @OneToOne(mappedBy = "user")
     private Wish wish;
 
+    public void addWish(Wish wish) {
+        this.wish = wish;
+    }
+
     public void updateWishDone() {
         this.wish.updateDone();
     }

--- a/src/main/java/com/postgraduate/domain/member/user/domain/service/UserSaveService.java
+++ b/src/main/java/com/postgraduate/domain/member/user/domain/service/UserSaveService.java
@@ -16,10 +16,12 @@ public class UserSaveService {
     }
 
     public void saveJunior(User user, Wish wish) {
+        user.addWish(wish);
         userRepository.saveJunior(user, wish);
     }
 
-    public void changeJunior(Wish wish) {
+    public void changeJunior(User user, Wish wish) {
+        user.addWish(wish);
         userRepository.changeJunior(wish);
     }
 }

--- a/src/main/java/com/postgraduate/global/auth/login/application/usecase/oauth/SignUpUseCase.java
+++ b/src/main/java/com/postgraduate/global/auth/login/application/usecase/oauth/SignUpUseCase.java
@@ -52,7 +52,7 @@ public class SignUpUseCase {
         userUtils.checkPhoneNumber(request.phoneNumber());
         User user = UserMapper.mapToUser(request, profileUtils.juniorProfile(rd.nextInt(5)));
         Wish wish = UserMapper.mapToWish(user, request);
-        userSaveService.saveJunior(user,wish);
+        userSaveService.saveJunior(user, wish);
         if (request.matchingReceive())
             bizppurioJuniorMessage.matchingWaiting(user);
         slackSignUpMessage.sendJuniorSignUp(user, wish);
@@ -76,7 +76,7 @@ public class SignUpUseCase {
 
     public void changeUser(User user, UserChangeRequest changeRequest) {
         Wish wish = UserMapper.mapToWish(user, changeRequest);
-        userSaveService.changeJunior(wish);
+        userSaveService.changeJunior(user, wish);
         if (changeRequest.matchingReceive())
             bizppurioJuniorMessage.matchingWaiting(user);
         slackSignUpMessage.sendJuniorSignUp(user, wish);


### PR DESCRIPTION
## 🦝 PR 요약
후배 가입(추가가입)시 토큰 발급 오류 해결

## ✨ PR 상세 내용
토큰 발급시, 후배 여부 확인 로직 변경에 의해 후배 유저 생성 후 후배 여부 조회 실패로 토큰 발급이 실패하는 문제 발생
-> 문제 발생 이전 기존 로직 : wishGetService에서 직접 user에 해당하는 wish 여부 확인하는 로직
-> 문제 발생 로직 : wishGetService를 사용하는 대신, User에 모든 책임을 지어준 후 user.isJunior를 호출하여 확인
-> 문제 발생 원인 : User를 막 생성한 직후, 트랜잭션 처리 이후 다시 조회하지 않는다면 User에는 Wish 객체가 따로 들어있지 않음
-> 문제 해결 : 두가지 방법 중 선택
1. 회원가입UseCase 사용 후 외부에서 UserGetService를 사용하여 트랜잭션이 완료된 이후 User를 조회 후 조회된 User 사용 (트랜잭션이 완료된 이후이기 때문에 DB에 존재하는 Wish를 함께 조회할 수 잇음
2. User에 Wish를 set하는 메소드 생성 후 User save시 `user.addWish(wish)` 를 사용 이렇게 하면, 트랜잭션이 완료된 상태가 아니더라도 wish가 들어간 객체가 되기 때문에 이어서 그대로 사용할 수 있음 -> 후배 회원을 생성하는 서비스의 메소드에 해당 코드를 추가하면 해결 가능
2번 방식 선택 (1번 선택시 트랜잭션 완료 이후, 조회하는 코드를 추가할 적절한 위치가 필요하며, 불필요한 쿼리 조회가 추가되기 때문에)

## 🚨 주의 사항
주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
