### PR TITLE
RAC-478 fix : 페이지당 10개로 변경

### DIFF
--- a/src/main/java/com/postgraduate/admin/domain/service/AdminPaymentService.java
+++ b/src/main/java/com/postgraduate/admin/domain/service/AdminPaymentService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AdminPaymentService {
     private final AdminPaymentRepository adminPaymentRepository;
-    private static final int PAYMENT_PAGE_SIZE = 20;
+    private static final int PAYMENT_PAGE_SIZE = 10;
 
     public Page<PaymentWithMentoringQuery> allPayments(Integer page) {
         if (page == null)

--- a/src/main/java/com/postgraduate/admin/domain/service/AdminSalaryService.java
+++ b/src/main/java/com/postgraduate/admin/domain/service/AdminSalaryService.java
@@ -20,7 +20,7 @@ import java.time.LocalDate;
 @Slf4j
 public class AdminSalaryService {
     private final AdminSalaryRepository adminSalaryRepository;
-    private static final int SALARY_PAGE_SIZE = 20;
+    private static final int SALARY_PAGE_SIZE = 10;
     public Page<Salary> findAllDoneSalary(Integer page) {
         if (page == null)
             page = 1;

--- a/src/main/java/com/postgraduate/admin/domain/service/AdminSeniorService.java
+++ b/src/main/java/com/postgraduate/admin/domain/service/AdminSeniorService.java
@@ -19,7 +19,7 @@ import static com.postgraduate.domain.member.senior.domain.entity.constant.Statu
 @RequiredArgsConstructor
 public class AdminSeniorService {
     private final AdminSeniorRepository adminSeniorRepository;
-    private static final int SENIOR_PAGE_SIZE = 20;
+    private static final int SENIOR_PAGE_SIZE = 10;
 
     public Page<Salary> allSeniors(Integer page) {
         if (page == null)

--- a/src/main/java/com/postgraduate/admin/domain/service/AdminUserService.java
+++ b/src/main/java/com/postgraduate/admin/domain/service/AdminUserService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AdminUserService {
     private final AdminUserRepository adminUserRepository;
-    private static final int JUNIOR_PAGE_SIZE = 20;
+    private static final int JUNIOR_PAGE_SIZE = 10;
     public Page<MemberRole> allJunior(Integer page) {
         if (page == null)
             page = 1;

--- a/src/main/java/com/postgraduate/admin/domain/service/AdminWishService.java
+++ b/src/main/java/com/postgraduate/admin/domain/service/AdminWishService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AdminWishService {
     private final AdminWishRepository adminWishRepository;
-    private static final int WISH_PAGE_SIZE = 20;
+    private static final int WISH_PAGE_SIZE = 10;
     public Page<Wish> findAllWaiting(Integer page) {
         if (page == null)
             page = 1;


### PR DESCRIPTION
## 🦝 PR 요약
페이지당 10개로 변경

## ✨ PR 상세 내용
20개 -> 10개 변경

## 🚨 주의 사항
주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Pagination size for payments, salaries, seniors, juniors, and wishes has been updated to return 10 items per page instead of 20.
  
- **Bug Fixes**
	- Adjusted pagination behavior to ensure consistent data retrieval across various services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->